### PR TITLE
Claude-style retry policy + retry visibility (frontend)

### DIFF
--- a/backend/src/core/events.ts
+++ b/backend/src/core/events.ts
@@ -17,6 +17,7 @@ export const RUN_EVENT_TYPES = [
   "run.completed",
   "run.failed",
   "run.cancelled",
+  "run.retry-pending",
   "part.added",
   "part.updated",
   "tool.started",
@@ -45,6 +46,20 @@ export type RunLifecycleEvent = EventBase<
 >;
 
 export type RunFailedEvent = EventBase<"run.failed"> & {
+  readonly error: PlatformError;
+};
+
+/**
+ * Emitted when a transient failure triggers a retry (see docs/04 → Retry policy).
+ * Carries enough for a client to render "attempt 2 of 5, retrying in ~3s (rate limited)"
+ * rather than only showing the `retry-pending` status.
+ */
+export type RunRetryPendingEvent = EventBase<"run.retry-pending"> & {
+  readonly attempt: number;
+  readonly maxAttempts: number;
+  /** When the next attempt is scheduled, honoring any `retry-after` the provider returned. */
+  readonly nextAttemptAt: string;
+  /** The transient error that triggered the retry. */
   readonly error: PlatformError;
 };
 
@@ -78,6 +93,7 @@ export type ContextCompactedEvent = EventBase<"context.compacted"> & {
 export type RunEvent =
   | RunLifecycleEvent
   | RunFailedEvent
+  | RunRetryPendingEvent
   | PartEvent
   | ToolEvent
   | InteractionEvent

--- a/docs/04-durable-runtime-and-hitl.md
+++ b/docs/04-durable-runtime-and-hitl.md
@@ -47,6 +47,22 @@ Per agent/run:
 - Retry count and backoff.
 - Maximum inline tool-output size.
 
+## Retry policy
+
+Transient failures are retried with a Claude/Anthropic-SDK-style policy rather than a naive
+fixed loop:
+
+- **Exponential backoff with jitter** between attempts, up to a bounded maximum attempt count.
+- **Honor server timing**: when the provider returns a `retry-after` / `retry-after-ms` header,
+  wait at least that long before the next attempt.
+- **Retry only transient classes**: `429` rate limits, `408`/`409`, `5xx`, and `529` overloaded.
+  Deterministic `4xx` validation errors are not retried — they fail fast.
+- **Retries are safe because writes are idempotent**: every external/destructive call carries an
+  idempotency key (see Idempotency below), so a retried publish/send/schedule returns the original
+  result instead of firing the side effect twice.
+- The run surfaces `RetryPending` between attempts; exhausting the attempt budget moves it to
+  `Failed` with the last error preserved.
+
 ## Questions
 
 `ask_questions` is used for consequential ambiguity that cannot be resolved from context or tools. Questions persist as typed message parts. The run moves to `WaitingForQuestion`; an answer mutation records the answer and queues a continuation.
@@ -89,4 +105,5 @@ Transports map these events to GraphQL subscriptions, SSE or another channel wit
 - Pending interactions survive deployment/restart.
 - Approval cannot be bypassed through direct tool execution.
 - Cancellation and retry states are observable and tested.
+- Retries use backoff with jitter, honor `retry-after`, retry only transient classes, and never double-fire an idempotent external write.
 

--- a/docs/04-durable-runtime-and-hitl.md
+++ b/docs/04-durable-runtime-and-hitl.md
@@ -62,6 +62,9 @@ fixed loop:
   result instead of firing the side effect twice.
 - The run surfaces `RetryPending` between attempts; exhausting the attempt budget moves it to
   `Failed` with the last error preserved.
+- Each retry emits a `run.retry-pending` transport event with attempt number, max attempts,
+  next-attempt time and the triggering error, so the frontend can show a live retry indicator
+  (attempt/countdown/reason) rather than only the status.
 
 ## Questions
 
@@ -89,6 +92,7 @@ Every external/destructive tool requires an idempotency key derived from tenant,
 Stable events include:
 
 - Run queued/started/checkpointed/completed/failed/cancelled.
+- Run retry-pending, carrying `attempt`, `maxAttempts`, `nextAttemptAt` and the triggering error.
 - Content part added/updated.
 - Tool started/completed/failed.
 - Question requested/answered.

--- a/docs/06-graphql-and-frontend.md
+++ b/docs/06-graphql-and-frontend.md
@@ -53,7 +53,7 @@ Required hooks:
 - `useAttachmentUpload`
 - `useArtifact`
 
-The package provides typed part reducers, optimistic sends, cursor catch-up, retry and cancellation. It contains no product styling.
+The package provides typed part reducers, optimistic sends, cursor catch-up, retry and cancellation. It contains no product styling. `useRunSubscription` exposes a `retry` state (attempt, max attempts, next-attempt time, reason) derived from the `run.retry-pending` event, which the "Error, retry and processing states" component renders as a live indicator.
 
 ## Optional UI package
 

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -45,6 +45,18 @@ export type UseSendMessage = (input: { conversationId: string }) => {
   readonly error: PlatformError | undefined;
 };
 
+/**
+ * Retry detail surfaced from the latest `run.retry-pending` event, so a UI can show
+ * "attempt 2 of 5, retrying in ~3s" and not just the bare `retry-pending` status.
+ * `undefined` once the run leaves `retry-pending`.
+ */
+export type RetryState = {
+  readonly attempt: number;
+  readonly maxAttempts: number;
+  readonly nextAttemptAt: string;
+  readonly reason: PlatformError;
+};
+
 export type UseRunSubscription = (input: {
   runId: string;
   /** Resume point after a reconnect, so no part is missed or rendered twice. */
@@ -53,6 +65,8 @@ export type UseRunSubscription = (input: {
   readonly status: RunStatus | undefined;
   readonly parts: readonly MessagePart[];
   readonly lastEvent: RunEvent | undefined;
+  /** Present while `status === "retry-pending"`; drives the retry indicator. */
+  readonly retry: RetryState | undefined;
   readonly connected: boolean;
 };
 


### PR DESCRIPTION
## Summary
Adds the Claude/Anthropic-SDK-style retry policy to the runtime spec **and** makes retries
visible end-to-end through the frontend package.

## Changes
**Spec**
- `docs/04` — Retry policy: backoff+jitter, honor `retry-after`, transient classes only
  (429/408/409/5xx/529), bounded attempts, safe via idempotency keys (no double-fire).

**Contract (code)**
- `core/events.ts` — new `run.retry-pending` transport event: `attempt`, `maxAttempts`,
  `nextAttemptAt`, triggering `error`.
- `frontend` — `RetryState` on `useRunSubscription`, so a client can render
  "attempt 2 of 5, retrying in ~3s".
- `docs/04` + `docs/06` — retry event + frontend retry-indicator notes.

Refs #19 #24 #36 #38