### PR TITLE
docs: localization (i18n) spec

### DIFF
--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -40,6 +40,7 @@ agent-platform/
 - Adapter packages implement ports; ports never import adapters.
 - Imported MCP tools flow through the same authorization and approval path as native tools.
 - Authorization is a port; services take decisions from it and never inline permission logic.
+- Contracts, events and tool results carry stable codes and structured data — never pre-localized user prose. The frontend localizes (see docs/14).
 - `react` is headless. `ui` depends on `react`, not vice versa.
 - GraphQL resolvers call application services and contain no domain logic.
 - ShareFlow registers tools, context providers, skills and agents through public interfaces.

--- a/docs/03-intelligence-runtime.md
+++ b/docs/03-intelligence-runtime.md
@@ -46,7 +46,7 @@ Agents are declarative, stored, versioned and auditable.
 
 ## Tool registry
 
-Tool descriptors declare name, label, description, category, input/output schemas, effect classification, approval policy and idempotency requirement.
+Tool descriptors declare name, label, description, category, input/output schemas, effect classification, approval policy and idempotency requirement. The model-facing description stays canonical; the user-facing label/description is localizable (a catalog key or locale map) per docs/14.
 
 Effects:
 

--- a/docs/06-graphql-and-frontend.md
+++ b/docs/06-graphql-and-frontend.md
@@ -70,6 +70,9 @@ Components:
 - Error, retry and processing states.
 
 Components support theming, internationalization, accessibility and custom part renderers.
+Internationalization is a locale-keyed message catalog that resolves stable backend codes (tool
+names, statuses, retry indicators, error codes) to display strings with ICU interpolation and a
+default-locale/raw-id fallback; a consuming app can register its own catalog. See docs/14.
 
 ## Mobile
 

--- a/docs/14-localization.md
+++ b/docs/14-localization.md
@@ -1,0 +1,68 @@
+# Localization (i18n)
+
+A user must be able to run the whole experience in their own language — tool-call names,
+retry indicators, statuses, errors and every other piece of UI chrome. This is a
+start-of-project decision because of one rule that is expensive to retrofit.
+
+## The core rule
+
+> **The backend emits stable machine identifiers and structured data — never pre-localized
+> UI prose. The frontend owns all localization.**
+
+If the runtime ever emitted `"Retrying in 3 seconds"` as a string, the client could never
+cleanly re-localize it. So everything the runtime, events and contracts produce is a stable
+code plus structured params:
+
+| Shown to the user | Backend emits (stable) | Frontend renders (localized) |
+|---|---|---|
+| Tool-call name | `create_post` (tool `name`) | `tool.create_post.label` → "Create post" / "Beitrag erstellen" |
+| Retry indicator | `run.retry-pending` + `{attempt, maxAttempts, nextAttemptAt}` | ICU `retry.pending` → "Versuch 2 von 5, erneut in ~3 s" |
+| Run status | `retry-pending` (enum) | `status.retry-pending` → localized label |
+| Error | `error.code` + safe params | `error.<code>` → localized message |
+| Assistant content / drafts | model output **in the target locale** | shown as-is |
+
+The locale comes from `ExecutionContext.locale` (docs/02); it is host-constructed and model
+input can never override it.
+
+## Frontend message catalog
+
+The `react`/`ui` packages resolve stable ids to display strings through a **locale-keyed
+message catalog**:
+
+- **Resolution**: `id → string` for the active locale.
+- **Interpolation**: ICU message format, fed the event's structured params (this is *why* the
+  retry event carries `attempt`/`maxAttempts`, not a sentence) — including plurals and
+  locale-aware number/date/currency via the `Intl` API. Timezone comes from context.
+- **Fallback chain**: requested locale → default locale → the raw id (never a blank string).
+- **Custom catalogs**: a consuming app registers its own catalog and overrides, merged over the
+  built-in one. Custom part renderers receive the same catalog.
+
+The catalog is data, not code, so adding a language is shipping a JSON file — no rebuild of the
+generic packages.
+
+## Localizable descriptor labels
+
+Tool and skill descriptors (docs/03) separate the two audiences:
+
+- **Model-facing** catalog/description stays canonical (English) — the model needs one stable
+  vocabulary, not translations.
+- **User-facing** `label`/`description` is localizable: either a catalog **key** the frontend
+  resolves, or a `locale → string` map on the descriptor. Integration-registered tools
+  (e.g. ShareFlow) ship their own catalog entries the same way.
+
+## Model-generated content
+
+UI chrome is localized on the client; the *content the model writes* (assistant messages,
+drafts) is produced in the target language by passing `locale` to the agent — already available
+in context. This is separate from chrome localization and is not catalog-driven.
+
+## Acceptance criteria
+
+- No backend contract, event or tool result carries pre-localized user prose — only stable
+  codes and structured params.
+- Switching `locale` re-renders every label, status, retry indicator and error without any
+  backend change.
+- A missing catalog key falls back to the default locale, then the raw id — never a blank.
+- A consuming app can register a custom catalog and override any built-in string.
+- Numbers, dates and currency render per the active locale via `Intl`; timezone from context.
+- Integration-registered tools localize their user-facing labels through the same catalog.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ This directory defines the extraction and migration of a reusable AI platform in
 - A first-class authorization model filtering tools, retrieval and every store call.
 - RAG, attachments, OCR, vision, PDF, document and artifact support.
 - GraphQL APIs/subscriptions, headless React hooks and optional UI components.
+- Full localization: the backend emits stable codes, the frontend renders them per user locale.
 - Token counting, usage/cost accounting with quotas, telemetry and versioned evaluations.
 
 ## Non-goals
@@ -45,6 +46,7 @@ This directory defines the extraction and migration of a reusable AI platform in
 11. [Authorization](11-authorization.md)
 12. [Usage, token counting and accounting](12-usage-and-accounting.md)
 13. [Sessions, threads and session state](13-sessions-and-threads.md)
+14. [Localization (i18n)](14-localization.md)
 
 ## Governing principles
 


### PR DESCRIPTION
## Summary
Adds localization as a foundational concern so tool names, retry indicators, statuses and errors
can render in the user's locale.

## Core rule
The backend emits stable codes + structured data (never localized prose); the frontend owns a
locale-keyed message catalog (ICU interpolation, fallback, custom catalogs).

## Changes
- `docs/14-localization.md` — the spec
- `docs/01` principle, `docs/03` localizable labels, `docs/06` catalog note, README index + goal

Introduces SPEC for REQ-008 (see linked issue).