### PR TITLE
fix(docs): TypeDoc resolves @agentkit/* from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install workspace
-        run: npm ci
-      - name: Build packages (emit dist/*.d.ts so TypeDoc resolves @agentkit/* types)
-        run: npm run build
       - name: Install (website)
         run: npm ci
         working-directory: website

--- a/website/README.md
+++ b/website/README.md
@@ -38,9 +38,9 @@ steps need your Cloudflare/DNS access; the config is already in the repo:**
 1. In the Cloudflare project (Workers & Pages → your `agentkit-docs` project) → **Settings →
    Build**, set:
    - **Root directory:** `website`  ← critical; without it Cloudflare builds the monorepo root.
-   - **Build command:** `(cd .. && npm ci && npm run build) && npm ci && npm run build`
-     — the first step installs + builds the `@agentkit/*` packages (emitting `dist/*.d.ts` so
-     TypeDoc can resolve cross-package types); the second installs the site and builds it.
+   - **Build command:** `npm run build`
+     — TypeDoc resolves `@agentkit/*` from source (`tsconfig.typedoc.json` paths), so no
+     workspace pre-build is needed.
    - **Deploy command:** `npx wrangler deploy` (default — it reads `website/wrangler.jsonc`).
 2. **Custom domain**: project → **Custom domains** → add **`docs.agentkit.riseexperts.de`**.
    - If `riseexperts.de` DNS is **on Cloudflare**, the record is created automatically.
@@ -56,6 +56,5 @@ and publishes automatically.
 > plus this `wrangler.jsonc` fixes both.
 
 ## Known follow-up
-TypeDoc emits a few broken `_media` links from source doc-comments that reference `../docs/*`
-(rendered as warnings; the build still passes). Tidy these by stripping doc-relative links from
-the API doc-comments or configuring the plugin's media handling.
+- AI search widget (kapa/Inkeep/Algolia AskAI) — wire in `themeConfig`, keys via env at deploy.
+- The `onBrokenMarkdownLinks` deprecation warning migrates to `markdown.hooks` in Docusaurus v4.

--- a/website/tsconfig.typedoc.json
+++ b/website/tsconfig.typedoc.json
@@ -1,0 +1,22 @@
+{
+  "//": "TypeDoc-only config. Resolves @agentkit/* imports from SOURCE (not built dist) via paths,",
+  "//2": "so the API reference generates without pre-building the workspace — works in CI, Cloudflare and locally.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": [],
+    "baseUrl": ".",
+    "paths": {
+      "@agentkit/backend": ["../backend/src/index.ts"],
+      "@agentkit/frontend": ["../frontend/src/index.ts"]
+    },
+    "noEmit": true
+  },
+  "include": ["../backend/src/index.ts", "../frontend/src/index.ts"]
+}

--- a/website/typedoc.json
+++ b/website/typedoc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPointStrategy": "packages",
-  "entryPoints": ["../backend", "../frontend"],
+  "entryPoints": ["../backend/src/index.ts", "../frontend/src/index.ts"],
+  "tsconfig": "tsconfig.typedoc.json",
   "plugin": ["typedoc-plugin-markdown"],
   "out": "api",
   "readme": "none",


### PR DESCRIPTION
## Problem
The Cloudflare deploy (and a fresh CI runner) failed with `TS2307: Cannot find module
'@agentkit/backend'` during `docs:api` — TypeDoc resolved the cross-package type-only import to
built `dist/*.d.ts` that doesn't exist unless the workspace is pre-built.

## Fix
- `website/tsconfig.typedoc.json` maps `@agentkit/backend|frontend` → `../*/src` (paths).
- `website/typedoc.json` runs a single-project conversion using that tsconfig, so the API
  reference generates **from source** — no `dist`, no workspace install needed.
- CI docs job and the Cloudflare **Build command** reduce back to plain `npm run build`.

## Verified
With `backend/dist` + `frontend/dist` removed (fresh-runner sim): `npm run build` → TypeDoc
generates 176 API pages, Docusaurus build SUCCESS, no TS2307.

Refs #50