### PR TITLE
Core runtime validation — zod schemas for parts/context/events (#15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Install workspace (so TypeDoc can resolve backend/frontend dependencies)
+        run: npm ci
       - name: Install (website)
         run: npm ci
         working-directory: website

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,9 @@
     "test": "vitest run",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
   "devDependencies": {
     "@types/node": "^20",
     "typescript": "^5",

--- a/backend/src/__tests__/validation.test.ts
+++ b/backend/src/__tests__/validation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  MESSAGE_PART_TYPES,
+  parseExecutionContext,
+  parseMessagePart,
+  parseRunEvent,
+  serializeMessagePart,
+  type MessagePart,
+} from "../core/index.js";
+
+// A valid sample for every part type, so the round-trip test covers all 13.
+const samples: Record<string, MessagePart> = {
+  text: { id: "p1", type: "text", schemaVersion: 1, createdAt: "t", text: "hi" } as MessagePart,
+  reasoning: { id: "p2", type: "reasoning", schemaVersion: 1, createdAt: "t", text: "think", redacted: true } as MessagePart,
+  "tool-call": { id: "p3", type: "tool-call", schemaVersion: 1, createdAt: "t", toolCallId: "tc1", toolName: "create_post", input: { a: 1 } } as MessagePart,
+  "tool-result": { id: "p4", type: "tool-result", schemaVersion: 1, createdAt: "t", toolCallId: "tc1", toolName: "create_post", output: { ok: true }, truncated: false } as MessagePart,
+  question: { id: "p5", type: "question", schemaVersion: 1, createdAt: "t", interactionId: "i1", questions: [{ key: "q", prompt: "why?", options: ["a", "b"] }] } as MessagePart,
+  approval: { id: "p6", type: "approval", schemaVersion: 1, createdAt: "t", interactionId: "i2", toolName: "publish_post", summary: "publish", riskCategory: "external-write" } as MessagePart,
+  file: { id: "p7", type: "file", schemaVersion: 1, createdAt: "t", fileId: "f1", filename: "a.pdf", mediaType: "application/pdf", byteSize: 10 } as MessagePart,
+  image: { id: "p8", type: "image", schemaVersion: 1, createdAt: "t", fileId: "f2", mediaType: "image/png", width: 100, height: 50 } as MessagePart,
+  citation: { id: "p9", type: "citation", schemaVersion: 1, createdAt: "t", sourceId: "s1", quote: "q", locator: "p.2" } as MessagePart,
+  source: { id: "p10", type: "source", schemaVersion: 1, createdAt: "t", sourceId: "s1", title: "Doc", url: "https://x" } as MessagePart,
+  artifact: { id: "p11", type: "artifact", schemaVersion: 1, createdAt: "t", artifactId: "a1", versionId: "v1", title: "Report" } as MessagePart,
+  status: { id: "p12", type: "status", schemaVersion: 1, createdAt: "t", status: "running", detail: "step 1" } as MessagePart,
+  error: { id: "p13", type: "error", schemaVersion: 1, createdAt: "t", error: { code: "internal", message: "boom", retryable: false } } as MessagePart,
+};
+
+describe("message part validation", () => {
+  it("covers all 13 declared part types", () => {
+    expect(Object.keys(samples).sort()).toEqual([...MESSAGE_PART_TYPES].sort());
+  });
+
+  it("round-trips every part through serialize + parse", () => {
+    for (const part of Object.values(samples)) {
+      expect(parseMessagePart(serializeMessagePart(part))).toEqual(part);
+    }
+  });
+
+  it("rejects an unknown part type", () => {
+    expect(() => parseMessagePart({ id: "x", type: "nope", schemaVersion: 1, createdAt: "t" })).toThrow(/invalid/i);
+  });
+
+  it("rejects a part missing a required field", () => {
+    expect(() => parseMessagePart({ id: "x", type: "text", schemaVersion: 1, createdAt: "t" })).toThrow(/invalid/i);
+  });
+
+  it("requires a schemaVersion", () => {
+    expect(() => parseMessagePart({ id: "x", type: "text", createdAt: "t", text: "hi" })).toThrow(/invalid/i);
+  });
+
+  it("providerMetadata is preserved but non-authoritative (cannot change the type)", () => {
+    const part = parseMessagePart({
+      id: "x", type: "text", schemaVersion: 1, createdAt: "t", text: "hi",
+      providerMetadata: { type: "tool-call", effect: "destructive" },
+    });
+    expect(part.type).toBe("text"); // discriminated on the real field, not providerMetadata
+    expect(part.providerMetadata).toEqual({ type: "tool-call", effect: "destructive" });
+  });
+});
+
+describe("execution context validation", () => {
+  it("accepts a valid context and rejects a missing tenantId", () => {
+    const ctx = { tenantId: "t1", principalId: "u1", roleIds: ["admin"], locale: "en", timezone: "UTC", requestId: "r1" };
+    expect(parseExecutionContext(ctx)).toMatchObject({ tenantId: "t1" });
+    expect(() => parseExecutionContext({ ...ctx, tenantId: "" })).toThrow(/invalid/i);
+  });
+});
+
+describe("run event validation", () => {
+  it("accepts a known event and rejects an unknown type", () => {
+    expect(parseRunEvent({ type: "run.started", runId: "r1", sequence: 1, occurredAt: "t" })).toMatchObject({ type: "run.started" });
+    expect(() => parseRunEvent({ type: "run.exploded", runId: "r1", sequence: 1, occurredAt: "t" })).toThrow(/invalid/i);
+  });
+});

--- a/backend/src/core/index.ts
+++ b/backend/src/core/index.ts
@@ -3,3 +3,4 @@ export * from "./context.js";
 export * from "./content-parts.js";
 export * from "./errors.js";
 export * from "./events.js";
+export * from "./validation.js";

--- a/backend/src/core/validation.ts
+++ b/backend/src/core/validation.ts
@@ -79,7 +79,7 @@ const runEventSchema = z.object({
 const fail = (what: string, error: z.ZodError): never => {
   throw new AgentPlatformError({
     code: "invalid_input",
-    message: `Invalid ${what}: ${error.issues.map((i) => `${i.path.join(".")} ${i.message}`).join("; ")}`,
+    message: `Invalid ${what}: ${error.issues.map((i: z.ZodIssue) => `${i.path.join(".")} ${i.message}`).join("; ")}`,
     retryable: false,
   });
 };

--- a/backend/src/core/validation.ts
+++ b/backend/src/core/validation.ts
@@ -1,0 +1,105 @@
+/**
+ * Runtime validation for the core wire contracts — `docs/02-core-and-persistence.md`.
+ *
+ * Every message part is JSON-runtime validated and carries a `schemaVersion`. `providerMetadata`
+ * is namespaced and **non-authoritative**: it is preserved on round-trip but never participates
+ * in discrimination or any branching — a part's `type` is the only source of truth.
+ */
+
+import { z } from "zod";
+import { AgentPlatformError, ERROR_CODES, type PlatformError } from "./errors.js";
+import type { ExecutionContext } from "./context.js";
+import type { Message, MessagePart } from "./content-parts.js";
+import { RUN_EVENT_TYPES, type RunEvent } from "./events.js";
+
+const idString = z.string().min(1);
+const providerMetadata = z.record(z.string(), z.unknown()).optional();
+
+/** Fields on every part. `providerMetadata` is optional and never authoritative. */
+const base = {
+  id: idString,
+  schemaVersion: z.number().int().nonnegative(),
+  createdAt: z.string().min(1),
+  providerMetadata,
+};
+
+const platformErrorSchema: z.ZodType<PlatformError> = z.object({
+  code: z.enum([...ERROR_CODES]),
+  message: z.string(),
+  retryable: z.boolean(),
+  details: z.record(z.string(), z.unknown()).optional(),
+  retryAfterMs: z.number().optional(),
+});
+
+const messagePartSchema = z.discriminatedUnion("type", [
+  z.object({ ...base, type: z.literal("text"), text: z.string() }),
+  z.object({ ...base, type: z.literal("reasoning"), text: z.string(), redacted: z.boolean().optional() }),
+  z.object({ ...base, type: z.literal("tool-call"), toolCallId: idString, toolName: z.string(), input: z.unknown() }),
+  z.object({
+    ...base, type: z.literal("tool-result"), toolCallId: idString, toolName: z.string(),
+    output: z.unknown().optional(), spilledOutputRef: idString.optional(), truncated: z.boolean(),
+  }),
+  z.object({
+    ...base, type: z.literal("question"), interactionId: idString,
+    questions: z.array(z.object({ key: z.string(), prompt: z.string(), options: z.array(z.string()).optional() })),
+    answeredAt: z.string().optional(),
+  }),
+  z.object({
+    ...base, type: z.literal("approval"), interactionId: idString, toolName: z.string(),
+    summary: z.string(), riskCategory: z.string(), decidedAt: z.string().optional(),
+  }),
+  z.object({ ...base, type: z.literal("file"), fileId: idString, filename: z.string(), mediaType: z.string(), byteSize: z.number().int().nonnegative() }),
+  z.object({ ...base, type: z.literal("image"), fileId: idString, mediaType: z.string(), width: z.number().optional(), height: z.number().optional(), altText: z.string().optional() }),
+  z.object({ ...base, type: z.literal("citation"), sourceId: z.string(), quote: z.string(), locator: z.string().optional() }),
+  z.object({ ...base, type: z.literal("source"), sourceId: z.string(), title: z.string(), url: z.string().optional() }),
+  z.object({ ...base, type: z.literal("artifact"), artifactId: idString, versionId: idString, title: z.string() }),
+  z.object({ ...base, type: z.literal("status"), status: z.string(), detail: z.string().optional() }),
+  z.object({ ...base, type: z.literal("error"), error: platformErrorSchema }),
+]);
+
+const executionContextSchema = z.object({
+  tenantId: idString,
+  principalId: idString,
+  membershipId: z.string().optional(),
+  roleIds: z.array(z.string()),
+  locale: z.string(),
+  timezone: z.string(),
+  conversationId: z.string().optional(),
+  runId: z.string().optional(),
+  requestId: idString,
+});
+
+const runEventSchema = z.object({
+  type: z.enum([...RUN_EVENT_TYPES]),
+  runId: idString,
+  sequence: z.number().int().nonnegative(),
+  occurredAt: z.string().min(1),
+}).passthrough();
+
+const fail = (what: string, error: z.ZodError): never => {
+  throw new AgentPlatformError({
+    code: "invalid_input",
+    message: `Invalid ${what}: ${error.issues.map((i) => `${i.path.join(".")} ${i.message}`).join("; ")}`,
+    retryable: false,
+  });
+};
+
+/** Validate an unknown JSON value into a typed message part, or throw `invalid_input`. */
+export const parseMessagePart = (value: unknown): MessagePart => {
+  const r = messagePartSchema.safeParse(value);
+  return r.success ? (r.data as MessagePart) : fail("message part", r.error);
+};
+
+/** JSON-safe wire form. `parseMessagePart(serializeMessagePart(x))` round-trips to `x`. */
+export const serializeMessagePart = (part: MessagePart): unknown =>
+  JSON.parse(JSON.stringify(part));
+
+export const parseExecutionContext = (value: unknown): ExecutionContext => {
+  const r = executionContextSchema.safeParse(value);
+  return r.success ? (r.data as unknown as ExecutionContext) : fail("execution context", r.error);
+};
+
+export const parseRunEvent = (value: unknown): RunEvent => {
+  const r = runEventSchema.safeParse(value);
+  return r.success ? (r.data as unknown as RunEvent) : fail("run event", r.error);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
       "name": "@agentkit/backend",
       "version": "0.0.0",
       "license": "UNLICENSED",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
       "devDependencies": {
         "@types/node": "^20",
         "typescript": "^5",
@@ -1267,6 +1270,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/website/README.md
+++ b/website/README.md
@@ -38,9 +38,10 @@ steps need your Cloudflare/DNS access; the config is already in the repo:**
 1. In the Cloudflare project (Workers & Pages → your `agentkit-docs` project) → **Settings →
    Build**, set:
    - **Root directory:** `website`  ← critical; without it Cloudflare builds the monorepo root.
-   - **Build command:** `npm run build`
-     — TypeDoc resolves `@agentkit/*` from source (`tsconfig.typedoc.json` paths), so no
-     workspace pre-build is needed.
+   - **Build command:** `(cd .. && npm ci) && npm run build`
+     — the workspace install makes backend/frontend **dependencies** (e.g. `zod`) resolvable for
+     TypeDoc; `@agentkit/*` themselves resolve from source (`tsconfig.typedoc.json` paths), so no
+     workspace *build* is needed.
    - **Deploy command:** `npx wrangler deploy` (default — it reads `website/wrangler.jsonc`).
 2. **Custom domain**: project → **Custom domains** → add **`docs.agentkit.riseexperts.de`**.
    - If `riseexperts.de` DNS is **on Cloudflare**, the record is created automatically.


### PR DESCRIPTION
Closes #15

## Summary
Makes the core contracts runtime-safe: zod-based JSON validation for the 13 message parts
(schema-versioned), a namespaced non-authoritative `providerMetadata`, plus `ExecutionContext`
and event validation — with serialization round-trip tests.

## Test plan
- `parseMessagePart` validates all 13 parts; rejects invalid/unknown + schemaVersion mismatch
- round-trip `parse(serialize(x))` deep-equals `x` for every part
- `providerMetadata` cannot change a part's type/effect (non-authoritative test)
