### PR TITLE
fix(docs): root-aware Cloudflare deploy commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:evals": "node --test evals/*.test.mjs",
     "evals:coverage": "node evals/coverage.mjs",
     "check:boundaries": "node scripts/check-boundaries.mjs",
+    "docs:build": "npm ci && npm --prefix website ci && npm --prefix website run build",
     "clean": "npm run clean --workspaces --if-present && rm -rf tsconfig.tsbuildinfo"
   },
   "devDependencies": {

--- a/website/README.md
+++ b/website/README.md
@@ -36,13 +36,17 @@ secret needed, Cloudflare builds from the connected repo on each push. One-time 
 steps need your Cloudflare/DNS access; the config is already in the repo:**
 
 1. In the Cloudflare project (Workers & Pages → your `agentkit-docs` project) → **Settings →
-   Build**, set:
-   - **Root directory:** `website`  ← critical; without it Cloudflare builds the monorepo root.
-   - **Build command:** `(cd .. && npm ci) && npm run build`
-     — the workspace install makes backend/frontend **dependencies** (e.g. `zod`) resolvable for
-     TypeDoc; `@agentkit/*` themselves resolve from source (`tsconfig.typedoc.json` paths), so no
-     workspace *build* is needed.
-   - **Deploy command:** `npx wrangler deploy` (default — it reads `website/wrangler.jsonc`).
+   Build**, set — these run from the **repo root**, so no "Root directory" is needed:
+   - **Root directory:** leave empty / repo root.
+   - **Build command:** `npm run docs:build`
+     — installs the workspace (so TypeDoc resolves backend deps like `zod`), installs the site,
+     and builds it (`@agentkit/*` resolve from source via `tsconfig.typedoc.json` paths).
+   - **Deploy command:** `npx wrangler deploy --config website/wrangler.jsonc`
+     — `assets.directory` in that config resolves to `website/build`, uploaded as static assets.
+
+   > The earlier failures happened because Cloudflare built at the repo root (running the
+   > monorepo `tsc -b` + `wrangler` with no config). The two commands above are **root-aware**,
+   > so they work regardless of the Root directory setting.
 2. **Custom domain**: project → **Custom domains** → add **`docs.agentkit.riseexperts.de`**.
    - If `riseexperts.de` DNS is **on Cloudflare**, the record is created automatically.
    - Otherwise add a DNS **CNAME**: `docs.agentkit` → `<worker>.workers.dev` (as shown in the

--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
-  // Cloudflare Workers Static Assets — serves the Docusaurus build output.
-  // Cloudflare's Git build runs (with Root directory = website): npm install -> npm run build
-  // -> npx wrangler deploy, which uploads ./build as static assets. No Worker script needed.
+  // Cloudflare Workers Static Assets — serves the Docusaurus build output (./build).
+  // Deployed from the repo root: `npm run docs:build` then
+  // `npx wrangler deploy --config website/wrangler.jsonc`. No Worker script needed.
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "agentkit-docs",
   "compatibility_date": "2024-11-01",


### PR DESCRIPTION
## Problem
Cloudflare's Git build kept running at the **repo root** (executing the monorepo `tsc -b`, then
`wrangler` with no config → "Missing entry-point/assets"). The "Root directory = website" setting
wasn't sticking.

## Fix — make it root-aware (no Root-directory needed)
- Root `docs:build` script: install workspace (TypeDoc resolves backend deps) + install site + build.
- Cloudflare settings become:
  - Build command: `npm run docs:build`
  - Deploy command: `npx wrangler deploy --config website/wrangler.jsonc`
  - Root directory: repo root (default)

Verified locally: `npm --prefix website run build` → `website/build/index.html`; `wrangler.jsonc`
`assets.directory: ./build` resolves to `website/build` via `--config`.