### PR TITLE
fix(docs): self-contained website build (resolve backend deps in TypeDoc)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install workspace (so TypeDoc can resolve backend/frontend dependencies)
-        run: npm ci
       - name: Install (website)
         run: npm ci
         working-directory: website
       - name: Build docs site
+        # prebuild installs the workspace (npm --prefix .. ci) so TypeDoc resolves backend deps
         run: npm run build
         working-directory: website

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test:evals": "node --test evals/*.test.mjs",
     "evals:coverage": "node evals/coverage.mjs",
     "check:boundaries": "node scripts/check-boundaries.mjs",
-    "docs:build": "npm ci && npm --prefix website ci && npm --prefix website run build",
     "clean": "npm run clean --workspaces --if-present && rm -rf tsconfig.tsbuildinfo"
   },
   "devDependencies": {

--- a/website/README.md
+++ b/website/README.md
@@ -36,17 +36,13 @@ secret needed, Cloudflare builds from the connected repo on each push. One-time 
 steps need your Cloudflare/DNS access; the config is already in the repo:**
 
 1. In the Cloudflare project (Workers & Pages → your `agentkit-docs` project) → **Settings →
-   Build**, set — these run from the **repo root**, so no "Root directory" is needed:
-   - **Root directory:** leave empty / repo root.
-   - **Build command:** `npm run docs:build`
-     — installs the workspace (so TypeDoc resolves backend deps like `zod`), installs the site,
-     and builds it (`@agentkit/*` resolve from source via `tsconfig.typedoc.json` paths).
-   - **Deploy command:** `npx wrangler deploy --config website/wrangler.jsonc`
-     — `assets.directory` in that config resolves to `website/build`, uploaded as static assets.
-
-   > The earlier failures happened because Cloudflare built at the repo root (running the
-   > monorepo `tsc -b` + `wrangler` with no config). The two commands above are **root-aware**,
-   > so they work regardless of the Root directory setting.
+   Build**, set:
+   - **Root directory:** `website`
+   - **Build command:** `npm run build`
+     — the site's `prebuild` runs `npm --prefix .. ci`, installing the workspace so TypeDoc can
+     resolve backend deps (e.g. `zod`); `@agentkit/*` resolve from source. Fully self-contained.
+   - **Deploy command:** `npx wrangler deploy` (reads `website/wrangler.jsonc`; **not**
+     `wrangler versions upload`, which stages a version without publishing to the live URL).
 2. **Custom domain**: project → **Custom domains** → add **`docs.agentkit.riseexperts.de`**.
    - If `riseexperts.de` DNS is **on Cloudflare**, the record is created automatically.
    - Otherwise add a DNS **CNAME**: `docs.agentkit` → `<worker>.workers.dev` (as shown in the

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docs:api": "typedoc",
     "docs:llms": "node scripts/gen-llms.mjs",
-    "prebuild": "npm run docs:api && npm run docs:llms",
+    "prebuild": "npm --prefix .. ci && npm run docs:api && npm run docs:llms",
     "build": "docusaurus build",
     "start": "docusaurus start",
     "serve": "docusaurus serve"


### PR DESCRIPTION
Cloudflare's `npm run build` (Root=website) failed with TS2307 'Cannot find module zod' because it didn't install the workspace. Fix: website `prebuild` runs `npm --prefix .. ci`, so `npm run build` is self-contained everywhere. Verified locally (build SUCCESS, zod resolved). Cloudflare settings: Root=website, Build=`npm run build`, Deploy=`npx wrangler deploy`.