### PR TITLE
Storage ports + in-memory adapter + conformance scaffold (#17)

### DIFF
--- a/backend/src/__tests__/memory-conformance.test.ts
+++ b/backend/src/__tests__/memory-conformance.test.ts
@@ -1,0 +1,6 @@
+import { createMemoryConversationStore } from "../adapters/memory/index.js";
+import { conversationStoreConformance } from "../testing/conformance.js";
+
+// The in-memory reference adapter must pass the shared conformance suite (tenant isolation,
+// pagination, optimistic concurrency, soft-delete) — the same suite every future adapter runs.
+conversationStoreConformance(() => createMemoryConversationStore());

--- a/backend/src/adapters/memory/index.ts
+++ b/backend/src/adapters/memory/index.ts
@@ -1,0 +1,88 @@
+/**
+ * In-memory reference adapters — `docs/02-core-and-persistence.md`.
+ *
+ * The reference implementation used for tests and dev. It implements the storage ports (never
+ * the other way round) and is verified by the shared conformance harness, so a Postgres/Supabase
+ * adapter can be checked against the exact same behavior.
+ */
+
+import { AgentPlatformError } from "../../core/errors.js";
+import type { Page } from "../../core/context.js";
+import type { Conversation, ConversationStore } from "../../persistence/index.js";
+
+const notFound = (id: string) =>
+  new AgentPlatformError({ code: "not_found", message: `Conversation ${id} not found`, retryable: false });
+const conflict = (message: string) =>
+  new AgentPlatformError({ code: "conflict", message, retryable: false });
+
+/** Monotonic ISO clock, injectable for deterministic tests. */
+const defaultClock = (): (() => string) => {
+  let n = 0;
+  return () => new Date(Date.UTC(2020, 0, 1, 0, 0, 0, ++n)).toISOString();
+};
+
+export const createMemoryConversationStore = (
+  clock: () => string = defaultClock(),
+): ConversationStore => {
+  // tenantId → (id → row). Partitioning by tenant makes cross-tenant reads structurally impossible.
+  const byTenant = new Map<string, Map<string, Conversation>>();
+  const tenant = (t: string) => {
+    let m = byTenant.get(t);
+    if (!m) byTenant.set(t, (m = new Map()));
+    return m;
+  };
+  const visible = (c: Conversation) => c.deletedAt === undefined;
+
+  return {
+    async create({ tenantId, id, title }) {
+      const rows = tenant(tenantId);
+      if (rows.has(id)) throw conflict(`Conversation ${id} already exists`);
+      const now = clock();
+      const row: Conversation = { id, tenantId, title, version: 1, createdAt: now, updatedAt: now };
+      rows.set(id, row);
+      return row;
+    },
+
+    async findById({ tenantId, id }) {
+      const row = tenant(tenantId).get(id);
+      return row && visible(row) ? row : null;
+    },
+
+    async list({ tenantId, limit, cursor }) {
+      const all = [...tenant(tenantId).values()]
+        .filter(visible)
+        .sort((a, b) => (a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id < b.id ? -1 : 1));
+      const start = cursor ? all.findIndex((c) => c.id === cursor) + 1 : 0;
+      const items = all.slice(start, start + limit);
+      const nextCursor = start + limit < all.length ? items[items.length - 1]?.id : undefined;
+      const page: Page<Conversation> = nextCursor === undefined ? { items } : { items, nextCursor };
+      return page;
+    },
+
+    async update({ tenantId, id, expectedVersion, patch }) {
+      const rows = tenant(tenantId);
+      const row = rows.get(id);
+      if (!row || !visible(row)) throw notFound(id);
+      if (row.version !== expectedVersion)
+        throw conflict(`Conversation ${id} version ${expectedVersion} is stale (current ${row.version})`);
+      const next: Conversation = {
+        ...row,
+        ...(patch.title === undefined ? {} : { title: patch.title }),
+        ...(patch.archivedAt === undefined
+          ? {}
+          : { archivedAt: patch.archivedAt === null ? undefined : patch.archivedAt }),
+        version: row.version + 1,
+        updatedAt: clock(),
+      };
+      rows.set(id, next);
+      return next;
+    },
+
+    async softDelete({ tenantId, id }) {
+      const rows = tenant(tenantId);
+      const row = rows.get(id);
+      if (!row || !visible(row)) throw notFound(id);
+      rows.set(id, { ...row, deletedAt: clock(), version: row.version + 1, updatedAt: clock() });
+    },
+  } satisfies ConversationStore;
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,3 +18,4 @@ export * from "./skills/index.js";
 export * from "./context/index.js";
 export * from "./hitl/index.js";
 export * from "./persistence/index.js";
+export * from "./adapters/memory/index.js";

--- a/backend/src/persistence/index.ts
+++ b/backend/src/persistence/index.ts
@@ -12,22 +12,44 @@
 import type { Page, PageRequest, TenantScope } from "../core/context.js";
 import type { Message } from "../core/content-parts.js";
 import type { AgentManifest } from "../agents/index.js";
-import type { ConversationId, MessageId, RunId } from "../core/ids.js";
+import type { ConversationId, MessageId, RunId, TenantId } from "../core/ids.js";
 import type { PendingApproval, PendingQuestion } from "../hitl/index.js";
 import type { Run } from "../runtime/index.js";
 import type { SkillCatalogEntry, SkillVersion } from "../skills/index.js";
 
 export type Conversation = {
   readonly id: ConversationId;
+  readonly tenantId: TenantId;
   readonly title: string;
+  /** Optimistic-concurrency version; incremented on every write. */
+  readonly version: number;
   readonly archivedAt?: string;
+  /** Set by soft-delete; `findById`/`list` hide soft-deleted rows. */
+  readonly deletedAt?: string;
   readonly createdAt: string;
   readonly updatedAt: string;
 };
 
+export type ConversationPatch = {
+  readonly title?: string;
+  /** `null` un-archives; a timestamp archives. */
+  readonly archivedAt?: string | null;
+};
+
+/**
+ * The exemplar store. **Every store follows this shape** (docs/02 mandatory method behavior):
+ * an explicit `{ tenantId }` on every call (bare `findById(id)` is a type error), cursor
+ * pagination on lists, `expectedVersion` optimistic concurrency on updates, and soft-delete
+ * semantics. Adapters are verified by the shared conformance harness.
+ */
 export interface ConversationStore {
+  create(input: TenantScope & { id: ConversationId; title: string }): Promise<Conversation>;
   findById(input: TenantScope & { id: ConversationId }): Promise<Conversation | null>;
   list(input: TenantScope & PageRequest): Promise<Page<Conversation>>;
+  update(
+    input: TenantScope & { id: ConversationId; expectedVersion: number; patch: ConversationPatch },
+  ): Promise<Conversation>;
+  softDelete(input: TenantScope & { id: ConversationId }): Promise<void>;
 }
 
 /**

--- a/backend/src/testing/conformance.ts
+++ b/backend/src/testing/conformance.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared storage conformance harness — `docs/02` "Conformance suite".
+ *
+ * Every `ConversationStore` adapter (memory today, Postgres/Supabase later) must pass the same
+ * suite, so "swap the database" is provably safe. Adapter packages call this from a test file.
+ * Not part of the published build (excluded in tsconfig); imported by tests only.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ConversationId, TenantId } from "../core/ids.js";
+import type { ConversationStore } from "../persistence/index.js";
+
+export function conversationStoreConformance(makeStore: () => ConversationStore): void {
+  const t1 = "tenant-1" as TenantId;
+  const t2 = "tenant-2" as TenantId;
+  const cid = (s: string) => s as ConversationId;
+
+  describe("ConversationStore conformance", () => {
+    it("create then findById returns the row, scoped to its tenant", async () => {
+      const store = makeStore();
+      const created = await store.create({ tenantId: t1, id: cid("c1"), title: "Hello" });
+      expect(created).toMatchObject({ id: "c1", tenantId: t1, title: "Hello", version: 1 });
+      expect(await store.findById({ tenantId: t1, id: cid("c1") })).toMatchObject({ id: "c1" });
+    });
+
+    it("enforces tenant isolation", async () => {
+      const store = makeStore();
+      await store.create({ tenantId: t1, id: cid("c1"), title: "t1 only" });
+      expect(await store.findById({ tenantId: t2, id: cid("c1") })).toBeNull();
+      expect((await store.list({ tenantId: t2, limit: 10 })).items).toHaveLength(0);
+    });
+
+    it("rejects a duplicate id", async () => {
+      const store = makeStore();
+      await store.create({ tenantId: t1, id: cid("c1"), title: "a" });
+      await expect(store.create({ tenantId: t1, id: cid("c1"), title: "b" })).rejects.toThrow();
+    });
+
+    it("paginates by stable cursor", async () => {
+      const store = makeStore();
+      for (const n of [1, 2, 3, 4, 5]) await store.create({ tenantId: t1, id: cid(`c${n}`), title: `#${n}` });
+      const first = await store.list({ tenantId: t1, limit: 2 });
+      expect(first.items).toHaveLength(2);
+      expect(first.nextCursor).toBeDefined();
+      const second = await store.list({ tenantId: t1, limit: 2, cursor: first.nextCursor });
+      expect(second.items).toHaveLength(2);
+      // no overlap between pages
+      const ids = new Set(first.items.map((c) => c.id));
+      expect(second.items.some((c) => ids.has(c.id))).toBe(false);
+    });
+
+    it("optimistic concurrency: a stale expectedVersion is rejected", async () => {
+      const store = makeStore();
+      await store.create({ tenantId: t1, id: cid("c1"), title: "v1" });
+      const updated = await store.update({ tenantId: t1, id: cid("c1"), expectedVersion: 1, patch: { title: "v2" } });
+      expect(updated.version).toBe(2);
+      await expect(
+        store.update({ tenantId: t1, id: cid("c1"), expectedVersion: 1, patch: { title: "stale" } }),
+      ).rejects.toThrow();
+    });
+
+    it("soft delete hides the row from findById and list", async () => {
+      const store = makeStore();
+      await store.create({ tenantId: t1, id: cid("c1"), title: "bye" });
+      await store.softDelete({ tenantId: t1, id: cid("c1") });
+      expect(await store.findById({ tenantId: t1, id: cid("c1") })).toBeNull();
+      expect((await store.list({ tenantId: t1, limit: 10 })).items).toHaveLength(0);
+    });
+  });
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -20,5 +20,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/__tests__/**"]
+  "exclude": ["node_modules", "dist", "src/__tests__/**", "src/testing/**"]
 }


### PR DESCRIPTION
Closes #17

## Summary
Completes the storage-port contract (docs/02 mandatory method behavior) with `ConversationStore`
as the fully-worked exemplar, an in-memory reference adapter, and a reusable conformance harness
every future adapter must pass. Closes REQ-002.

## Test plan
- bare `findById(id)` is a type error (all methods take `TenantScope & {...}`)
- conformance harness green against the in-memory adapter: tenant isolation, CRUD, cursor
  pagination, optimistic-concurrency conflict, soft-delete visibility
