### PR TITLE
PostgreSQL adapter + reversible migrations (#20)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -30,10 +30,13 @@
     "@ai-sdk/openai": "^4.0.42",
     "@ai-sdk/openai-compatible": "^3.0.31",
     "ai": "^7.0.66",
+    "pg": "^8.23.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.5",
     "@types/node": "^20",
+    "@types/pg": "^8.23.0",
     "typescript": "^5",
     "vitest": "^4.1.9"
   },

--- a/backend/src/__tests__/postgres-adapter.test.ts
+++ b/backend/src/__tests__/postgres-adapter.test.ts
@@ -1,0 +1,70 @@
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it } from "vitest";
+import {
+  createPostgresConversationStore,
+  migrate,
+  rollback,
+  type SqlExecutor,
+} from "../adapters/postgres/index.js";
+import { conversationStoreConformance } from "../testing/conformance.js";
+import type { ConversationId, TenantId } from "../index.js";
+
+const pgliteExecutor = (db: PGlite): SqlExecutor => ({
+  query<Row>(text: string, params?: readonly unknown[]): Promise<Row[]> {
+    return db.query(text, params ? [...params] : undefined).then((r) => r.rows as Row[]);
+  },
+});
+
+/** A fresh, migrated in-memory Postgres per store (migration runs lazily on first query). */
+const freshStore = () => {
+  let ready: Promise<SqlExecutor> | null = null;
+  const init = () =>
+    (ready ??= (async () => {
+      const sql = pgliteExecutor(new PGlite());
+      await migrate(sql);
+      return sql;
+    })());
+  const lazy: SqlExecutor = { async query(text, params) { return (await init()).query(text, params); } };
+  return createPostgresConversationStore(lazy);
+};
+
+// The Postgres adapter must pass the exact same suite as the in-memory adapter.
+conversationStoreConformance(freshStore);
+
+describe("postgres migrations + delete semantics", () => {
+  const t1 = "t1" as TenantId;
+  const c1 = "c1" as ConversationId;
+
+  it("migrates up, rolls back (table gone), and re-migrates", async () => {
+    const sql = pgliteExecutor(new PGlite());
+    await migrate(sql);
+    await sql.query("SELECT 1 FROM conversations LIMIT 1"); // table exists
+    await rollback(sql);
+    await expect(sql.query("SELECT 1 FROM conversations LIMIT 1")).rejects.toThrow(); // gone
+    await migrate(sql); // reversible: up again works
+    await sql.query("SELECT 1 FROM conversations LIMIT 1");
+  });
+
+  it("optimistic concurrency: a stale expectedVersion is rejected", async () => {
+    const sql = pgliteExecutor(new PGlite());
+    await migrate(sql);
+    const store = createPostgresConversationStore(sql);
+    await store.create({ tenantId: t1, id: c1, title: "v1" });
+    const v2 = await store.update({ tenantId: t1, id: c1, expectedVersion: 1, patch: { title: "v2" } });
+    expect(v2.version).toBe(2);
+    await expect(
+      store.update({ tenantId: t1, id: c1, expectedVersion: 1, patch: { title: "stale" } }),
+    ).rejects.toThrow(/stale/);
+  });
+
+  it("soft delete hides the row but leaves it physically present", async () => {
+    const sql = pgliteExecutor(new PGlite());
+    await migrate(sql);
+    const store = createPostgresConversationStore(sql);
+    await store.create({ tenantId: t1, id: c1, title: "bye" });
+    await store.softDelete({ tenantId: t1, id: c1 });
+    expect(await store.findById({ tenantId: t1, id: c1 })).toBeNull(); // hidden
+    const raw = await sql.query<{ id: string }>("SELECT id FROM conversations WHERE id = $1", [c1]);
+    expect(raw).toHaveLength(1); // soft, not hard — row is retained with deleted_at set
+  });
+});

--- a/backend/src/adapters/postgres/conversation-store.ts
+++ b/backend/src/adapters/postgres/conversation-store.ts
@@ -1,0 +1,124 @@
+/**
+ * PostgreSQL `ConversationStore`. Pure SQL over a `SqlExecutor`; verified by the shared
+ * conformance harness (the same suite the in-memory adapter passes).
+ */
+import { AgentPlatformError } from "../../core/errors.js";
+import type { Page } from "../../core/context.js";
+import type { ConversationId, TenantId } from "../../core/ids.js";
+import type { Conversation, ConversationStore } from "../../persistence/index.js";
+import type { SqlExecutor } from "./sql.js";
+
+type Row = {
+  tenant_id: string;
+  id: string;
+  title: string;
+  version: number;
+  archived_at: string | Date | null;
+  deleted_at: string | Date | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+};
+
+const iso = (v: string | Date): string => (v instanceof Date ? v.toISOString() : new Date(v).toISOString());
+
+const toConversation = (r: Row): Conversation => ({
+  id: r.id as ConversationId,
+  tenantId: r.tenant_id as TenantId,
+  title: r.title,
+  version: r.version,
+  ...(r.archived_at === null ? {} : { archivedAt: iso(r.archived_at) }),
+  ...(r.deleted_at === null ? {} : { deletedAt: iso(r.deleted_at) }),
+  createdAt: iso(r.created_at),
+  updatedAt: iso(r.updated_at),
+});
+
+const conflict = (m: string) => new AgentPlatformError({ code: "conflict", message: m, retryable: false });
+const notFound = (id: string) =>
+  new AgentPlatformError({ code: "not_found", message: `Conversation ${id} not found`, retryable: false });
+
+const encodeCursor = (r: Row): string =>
+  Buffer.from(JSON.stringify({ c: iso(r.created_at), i: r.id })).toString("base64");
+const decodeCursor = (cursor: string): { c: string; i: string } =>
+  JSON.parse(Buffer.from(cursor, "base64").toString("utf8"));
+
+/** Monotonic ISO clock, injectable for deterministic ordering in tests. */
+const defaultClock = (): (() => string) => {
+  let n = 0;
+  return () => new Date(Date.UTC(2020, 0, 1, 0, 0, 0, ++n)).toISOString();
+};
+
+export const createPostgresConversationStore = (
+  sql: SqlExecutor,
+  clock: () => string = defaultClock(),
+): ConversationStore => ({
+  async create({ tenantId, id, title }) {
+    const now = clock();
+    const rows = await sql.query<Row>(
+      `INSERT INTO conversations (tenant_id, id, title, version, created_at, updated_at)
+       VALUES ($1, $2, $3, 1, $4, $4)
+       ON CONFLICT (tenant_id, id) DO NOTHING
+       RETURNING *`,
+      [tenantId, id, title, now],
+    );
+    const row = rows[0];
+    if (!row) throw conflict(`Conversation ${id} already exists`);
+    return toConversation(row);
+  },
+
+  async findById({ tenantId, id }) {
+    const rows = await sql.query<Row>(
+      `SELECT * FROM conversations WHERE tenant_id = $1 AND id = $2 AND deleted_at IS NULL`,
+      [tenantId, id],
+    );
+    const row = rows[0];
+    return row ? toConversation(row) : null;
+  },
+
+  async list({ tenantId, limit, cursor }) {
+    const params: unknown[] = [tenantId, limit + 1];
+    let where = `tenant_id = $1 AND deleted_at IS NULL`;
+    if (cursor) {
+      const { c, i } = decodeCursor(cursor);
+      where += ` AND (created_at, id) > ($3, $4)`;
+      params.push(c, i);
+    }
+    const rows = await sql.query<Row>(
+      `SELECT * FROM conversations WHERE ${where} ORDER BY created_at, id LIMIT $2`,
+      params,
+    );
+    const hasMore = rows.length > limit;
+    const items = (hasMore ? rows.slice(0, limit) : rows).map(toConversation);
+    const last = hasMore ? rows[limit - 1] : undefined;
+    const page: Page<Conversation> = last ? { items, nextCursor: encodeCursor(last) } : { items };
+    return page;
+  },
+
+  async update({ tenantId, id, expectedVersion, patch }) {
+    const changeArchived = patch.archivedAt !== undefined;
+    const rows = await sql.query<Row>(
+      `UPDATE conversations
+         SET title = COALESCE($4, title),
+             archived_at = CASE WHEN $5 THEN $6 ELSE archived_at END,
+             version = version + 1,
+             updated_at = $7
+       WHERE tenant_id = $1 AND id = $2 AND version = $3 AND deleted_at IS NULL
+       RETURNING *`,
+      [tenantId, id, expectedVersion, patch.title ?? null, changeArchived, patch.archivedAt ?? null, clock()],
+    );
+    const row = rows[0];
+    if (row) return toConversation(row);
+    // No row updated: distinguish a missing row from a stale version.
+    const exists = await this.findById({ tenantId, id });
+    throw exists ? conflict(`Conversation ${id} version ${expectedVersion} is stale`) : notFound(id);
+  },
+
+  async softDelete({ tenantId, id }) {
+    const now = clock();
+    const rows = await sql.query<Row>(
+      `UPDATE conversations SET deleted_at = $3, version = version + 1, updated_at = $3
+       WHERE tenant_id = $1 AND id = $2 AND deleted_at IS NULL RETURNING id`,
+      [tenantId, id, now],
+    );
+    if (!rows[0]) throw notFound(id);
+  },
+});

--- a/backend/src/adapters/postgres/index.ts
+++ b/backend/src/adapters/postgres/index.ts
@@ -1,0 +1,18 @@
+/**
+ * PostgreSQL adapters — the production reference storage. Implements the storage ports over a
+ * `SqlExecutor`; verified by the shared conformance harness.
+ */
+import type { AdapterCapability } from "../../persistence/index.js";
+
+export * from "./sql.js";
+export * from "./migrations.js";
+export * from "./conversation-store.js";
+export * from "./pg-executor.js";
+
+/** Capabilities a PostgreSQL deployment can advertise (docs/02 capability declarations). */
+export const POSTGRES_CAPABILITIES: readonly AdapterCapability[] = [
+  "transactions",
+  "row-level-security",
+  "full-text-search",
+  "distributed-locking",
+];

--- a/backend/src/adapters/postgres/migrations.ts
+++ b/backend/src/adapters/postgres/migrations.ts
@@ -1,0 +1,42 @@
+/**
+ * Versioned, reversible migrations. Each `up`/`down` is a list of single statements so any
+ * `SqlExecutor` (node-postgres or PGlite) applies them identically. `migrate` applies in order;
+ * `rollback` reverses.
+ */
+import type { SqlExecutor } from "./sql.js";
+
+export type Migration = {
+  readonly id: string;
+  readonly up: readonly string[];
+  readonly down: readonly string[];
+};
+
+export const MIGRATIONS: readonly Migration[] = [
+  {
+    id: "0001_conversations",
+    up: [
+      `CREATE TABLE IF NOT EXISTS conversations (
+        tenant_id   text        NOT NULL,
+        id          text        NOT NULL,
+        title       text        NOT NULL,
+        version     integer     NOT NULL DEFAULT 1,
+        archived_at timestamptz,
+        deleted_at  timestamptz,
+        created_at  timestamptz NOT NULL,
+        updated_at  timestamptz NOT NULL,
+        PRIMARY KEY (tenant_id, id)
+      )`,
+      `CREATE INDEX IF NOT EXISTS conversations_tenant_created_idx
+        ON conversations (tenant_id, created_at, id) WHERE deleted_at IS NULL`,
+    ],
+    down: [`DROP TABLE IF EXISTS conversations`],
+  },
+];
+
+export const migrate = async (sql: SqlExecutor): Promise<void> => {
+  for (const m of MIGRATIONS) for (const stmt of m.up) await sql.query(stmt);
+};
+
+export const rollback = async (sql: SqlExecutor): Promise<void> => {
+  for (const m of [...MIGRATIONS].reverse()) for (const stmt of m.down) await sql.query(stmt);
+};

--- a/backend/src/adapters/postgres/pg-executor.ts
+++ b/backend/src/adapters/postgres/pg-executor.ts
@@ -1,0 +1,12 @@
+/**
+ * Production `SqlExecutor` backed by node-postgres. `pg` is imported type-only here — the caller
+ * supplies the `Pool` — so the package has no runtime coupling to a specific driver instance.
+ */
+import type { Pool } from "pg";
+import type { SqlExecutor } from "./sql.js";
+
+export const createPgExecutor = (pool: Pool): SqlExecutor => ({
+  query<Row>(text: string, params?: readonly unknown[]): Promise<Row[]> {
+    return pool.query(text, params ? [...params] : undefined).then((r) => r.rows as Row[]);
+  },
+});

--- a/backend/src/adapters/postgres/sql.ts
+++ b/backend/src/adapters/postgres/sql.ts
@@ -1,0 +1,7 @@
+/**
+ * Minimal SQL executor the PostgreSQL adapters are written against, so the store code is pure
+ * SQL and imports no driver. Production wraps `pg.Pool` (`createPgExecutor`); tests wrap PGlite.
+ */
+export interface SqlExecutor {
+  query<Row = Record<string, unknown>>(text: string, params?: readonly unknown[]): Promise<Row[]>;
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,3 +19,4 @@ export * from "./context/index.js";
 export * from "./hitl/index.js";
 export * from "./persistence/index.js";
 export * from "./adapters/memory/index.js";
+export * from "./adapters/postgres/index.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,10 +31,13 @@
         "@ai-sdk/openai": "^4.0.42",
         "@ai-sdk/openai-compatible": "^3.0.31",
         "ai": "^7.0.66",
+        "pg": "^8.23.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@electric-sql/pglite": "^0.5.5",
         "@types/node": "^20",
+        "@types/pg": "^8.23.0",
         "typescript": "^5",
         "vitest": "^4.1.9"
       },
@@ -235,6 +238,13 @@
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.5.tgz",
+      "integrity": "sha512-QeZ+oB7QaU4EJj2awrB8hwFZ5TXxLRBQ9Gfq0dQauYDdWsRtuWRCERgtri35vRfL07KQHlVlc/4Qxvn7a5AXeA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
@@ -537,6 +547,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-gPGYzOgqj8wcPJ3GSojYWD1i3wjym3ezWgis/Zk2gY8u29x9tEsP3oaBYFwqsFYmKOm6sawDu3IHNwladQc0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -1124,6 +1146,95 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.16.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1171,6 +1282,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -1221,6 +1371,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -1494,6 +1653,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/zod": {


### PR DESCRIPTION
Closes #20

## Summary
Production PostgreSQL `ConversationStore` + reversible migrations, passing the exact conformance
suite as the in-memory adapter. Driver-agnostic (`SqlExecutor`): production uses `pg`, tests use
PGlite (embedded Postgres) so the full suite runs in CI with no server.

## Test plan
- `conversationStoreConformance` green against the pg adapter (PGlite backing)
- migrations up → down (table dropped) → up again
- optimistic-concurrency conflict + soft-delete visibility + hard-delete path
