### PR TITLE
Authorization engine: policy, tool filtering, scope() (#23)

### DIFF
--- a/backend/src/__tests__/authorization.test.ts
+++ b/backend/src/__tests__/authorization.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  assertToolAuthorized,
+  createAuthorizationPolicy,
+  tenantRlsFilter,
+  type AuditEvent,
+  type ExecutionContext,
+  type ToolDescriptor,
+} from "../index.js";
+
+const ctx = (roleIds: string[], tenantId = "t1"): ExecutionContext =>
+  ({ tenantId, principalId: "p1", roleIds, locale: "en", timezone: "UTC", requestId: "r1" }) as unknown as ExecutionContext;
+
+const tool = (name: string, category: string): ToolDescriptor =>
+  ({
+    name, label: name, description: "", category,
+    inputSchema: {}, outputSchema: {}, effect: "external-write",
+    approvalPolicy: "required", requiresIdempotencyKey: true,
+  }) as ToolDescriptor;
+
+const audit = vi.fn<(e: AuditEvent) => void>();
+const policy = createAuthorizationPolicy({
+  audit,
+  roles: [
+    { roleId: "editor", permissions: [{ action: "read", resourceType: "conversation" }], tools: ["create_post", "publishing"] },
+    { roleId: "viewer", permissions: [{ action: "read", resourceType: "conversation" }] },
+  ],
+});
+
+const createPost = tool("create_post", "posts");
+const publish = tool("publish_post", "publishing"); // allowed by category
+const secret = tool("billing_export", "billing"); // not allowed
+
+describe("authorization engine", () => {
+  it("filters unauthorized tools from discovery", async () => {
+    const forEditor = await policy.filterTools(ctx(["editor"]), [createPost, publish, secret]);
+    expect(forEditor.map((t) => t.name)).toEqual(["create_post", "publish_post"]); // secret dropped
+    const forViewer = await policy.filterTools(ctx(["viewer"]), [createPost, publish, secret]);
+    expect(forViewer).toHaveLength(0);
+  });
+
+  it("rejects an unauthorized tool on direct execution", async () => {
+    await expect(assertToolAuthorized(policy, ctx(["editor"]), createPost)).resolves.toBeUndefined();
+    await expect(assertToolAuthorized(policy, ctx(["editor"]), secret)).rejects.toThrow(/not permitted|not authorized/);
+    await expect(assertToolAuthorized(policy, ctx(["viewer"]), createPost)).rejects.toThrow();
+  });
+
+  it("scope() agrees with the RLS predicate", async () => {
+    const s = await policy.scope(ctx(["editor"]), "conversation");
+    expect(s.filter).toEqual(tenantRlsFilter("t1"));
+    expect(s).toMatchObject({ tenantId: "t1", roleIds: ["editor"] });
+  });
+
+  it("denies a cross-tenant resource", async () => {
+    const d = await policy.can(ctx(["editor"], "t1"), "read", { type: "conversation", attributes: { tenantId: "t2" } });
+    expect(d.allow).toBe(false);
+    expect(d.reason).toBe("cross-tenant");
+  });
+
+  it("audits denials", async () => {
+    audit.mockClear();
+    await policy.can(ctx(["viewer"]), "read", { type: "billing" }); // no permission
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({ kind: "denied" }));
+  });
+});

--- a/backend/src/authorization/index.ts
+++ b/backend/src/authorization/index.ts
@@ -6,6 +6,7 @@
  * never an adapter.
  */
 
+import { AgentPlatformError } from "../core/errors.js";
 import type { ExecutionContext } from "../core/context.js";
 import type { ToolDescriptor } from "../tools/index.js";
 
@@ -43,3 +44,121 @@ export interface AuthorizationPolicy {
   /** The scope filter for a resource type, applied before any list/search. */
   scope(context: ExecutionContext, resourceType: string): Promise<PermissionScope>;
 }
+
+// ---------------------------------------------------------------------------
+// Reference engine (REQ-004). A role→permission model; tenant policy may restrict but never
+// widen it. The engine is deterministic and cache-safe for the life of a request.
+// ---------------------------------------------------------------------------
+
+export type Permission = {
+  /** e.g. "read" | "execute" | "publish" | "*" */
+  readonly action: string;
+  /** e.g. "conversation" | "tool" | "*" */
+  readonly resourceType: string;
+  /** When true, a granted decision carries a requires-approval obligation. */
+  readonly requiresApproval?: boolean;
+};
+
+export type RoleDefinition = {
+  readonly roleId: string;
+  readonly permissions: readonly Permission[];
+  /** Tool names or categories this role may discover and execute. */
+  readonly tools?: readonly string[];
+};
+
+export type AuditEvent = {
+  readonly kind: "denied" | "allowed-write";
+  readonly tenantId: string;
+  readonly principalId: string;
+  readonly action: string;
+  readonly resource: ResourceRef;
+  readonly reason?: string;
+};
+
+export type AuthorizationConfig = {
+  readonly roles: readonly RoleDefinition[];
+  /** Sink for denials and allowed external writes (docs/11 auditing). */
+  readonly audit?: (event: AuditEvent) => void;
+};
+
+const WRITE_ACTIONS = new Set(["create", "update", "delete", "publish", "send", "execute"]);
+
+/** The tenant predicate `scope()` produces — the same rule a Supabase RLS policy enforces. */
+export const tenantRlsFilter = (tenantId: string): Readonly<Record<string, unknown>> => ({
+  tenant_id: tenantId,
+});
+
+export const createAuthorizationPolicy = (config: AuthorizationConfig): AuthorizationPolicy => {
+  const roleMap = new Map(config.roles.map((r) => [r.roleId, r] as const));
+  const rolesOf = (ctx: ExecutionContext): RoleDefinition[] =>
+    ctx.roleIds.map((id) => roleMap.get(id)).filter((r): r is RoleDefinition => r !== undefined);
+  const matches = (p: Permission, action: string, type: string): boolean =>
+    (p.action === "*" || p.action === action) && (p.resourceType === "*" || p.resourceType === type);
+
+  return {
+    async can(context, action, resource) {
+      const audit = (kind: AuditEvent["kind"], reason?: string) =>
+        config.audit?.({ kind, tenantId: context.tenantId, principalId: context.principalId, action, resource, ...(reason ? { reason } : {}) });
+
+      // Cross-tenant guard: a resource carrying another tenant's id is never visible.
+      const rt = resource.attributes?.["tenantId"];
+      if (typeof rt === "string" && rt !== context.tenantId) {
+        audit("denied", "cross-tenant");
+        return { allow: false, reason: "cross-tenant" };
+      }
+      // Tools are governed by the role's allow-list (name or category), so discovery and
+      // execution use the exact same rule.
+      if (resource.type === "tool") {
+        const allowed = new Set(rolesOf(context).flatMap((r) => r.tools ?? []));
+        const category = resource.attributes?.["category"];
+        const ok =
+          (resource.id !== undefined && allowed.has(resource.id)) ||
+          (typeof category === "string" && allowed.has(category));
+        if (!ok) {
+          audit("denied", "tool not permitted");
+          return { allow: false, reason: `tool ${resource.id ?? "?"} not permitted` };
+        }
+        audit("allowed-write");
+        return { allow: true };
+      }
+      const perm = rolesOf(context).flatMap((r) => r.permissions).find((p) => matches(p, action, resource.type));
+      if (!perm) {
+        audit("denied", "no permission");
+        return { allow: false, reason: `no permission for ${action} on ${resource.type}` };
+      }
+      if (WRITE_ACTIONS.has(action)) audit("allowed-write");
+      return perm.requiresApproval
+        ? { allow: true, obligations: [{ kind: "requires-approval" }] }
+        : { allow: true };
+    },
+
+    async filterTools(context, tools) {
+      const allowed = new Set(rolesOf(context).flatMap((r) => r.tools ?? []));
+      return tools.filter((t) => allowed.has(t.name) || allowed.has(t.category));
+    },
+
+    async scope(context) {
+      return { tenantId: context.tenantId, roleIds: context.roleIds, filter: tenantRlsFilter(context.tenantId) };
+    },
+  };
+};
+
+/** Guard for the execution path: throws `forbidden` when the tool may not run. */
+export const assertToolAuthorized = async (
+  policy: AuthorizationPolicy,
+  context: ExecutionContext,
+  tool: { readonly name: string; readonly category: string },
+): Promise<void> => {
+  const decision = await policy.can(context, "execute", {
+    type: "tool",
+    id: tool.name,
+    attributes: { category: tool.category },
+  });
+  if (!decision.allow) {
+    throw new AgentPlatformError({
+      code: "forbidden",
+      message: decision.reason ?? `Tool ${tool.name} is not authorized`,
+      retryable: false,
+    });
+  }
+};


### PR DESCRIPTION
Closes #23

## Summary
Real AuthorizationPolicy behind the #16 port: role→permission model driving can/filterTools/scope,
with obligations, cross-tenant denial, and an audit hook. scope() yields the same tenant predicate
the RLS policy uses.

## Test plan
- unauthorized tools absent from discovery + can(execute, tool) denies
- scope().filter deep-equals the documented RLS predicate
- cross-tenant resource is denied; scope always tenant-filters
