### PR TITLE
Automatic schema provisioning (SchemaManager) (#22)

### DIFF
--- a/backend/src/__tests__/schema-provisioning.test.ts
+++ b/backend/src/__tests__/schema-provisioning.test.ts
@@ -1,0 +1,56 @@
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it, vi } from "vitest";
+import { createSchemaManager, provisionSchema, type SqlExecutor } from "../adapters/postgres/index.js";
+
+const executor = (): SqlExecutor => {
+  const db = new PGlite();
+  return { query: (text, params) => db.query(text, params ? [...params] : undefined).then((r) => r.rows as never) };
+};
+
+const hasConversations = async (sql: SqlExecutor): Promise<boolean> => {
+  try {
+    await sql.query("SELECT 1 FROM conversations LIMIT 1");
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe("schema provisioning", () => {
+  it("auto provisions a fresh database", async () => {
+    const sql = executor();
+    const mgr = createSchemaManager(sql);
+    expect(await mgr.currentVersion()).toBe(0);
+    const res = await provisionSchema(sql, { mode: "auto" });
+    expect(res.applied.length).toBeGreaterThan(0);
+    expect(await mgr.currentVersion()).toBe(mgr.targetVersion());
+    expect(await hasConversations(sql)).toBe(true);
+  });
+
+  it("plan mode logs the diff and applies nothing", async () => {
+    const sql = executor();
+    const log = vi.fn();
+    const res = await provisionSchema(sql, { mode: "plan", log });
+    expect(res.planned.length).toBeGreaterThan(0);
+    expect(res.applied).toHaveLength(0);
+    expect(log).toHaveBeenCalled();
+    expect(await hasConversations(sql)).toBe(false); // DB untouched
+    expect(await createSchemaManager(sql).currentVersion()).toBe(0);
+  });
+
+  it("apply run twice is a no-op — no double-provision", async () => {
+    const sql = executor();
+    await provisionSchema(sql, { mode: "auto" });
+    const second = await provisionSchema(sql, { mode: "auto" });
+    expect(second.applied).toHaveLength(0);
+    const mgr = createSchemaManager(sql);
+    expect(await mgr.currentVersion()).toBe(mgr.targetVersion());
+  });
+
+  it("off mode is a no-op (Postgres default)", async () => {
+    const sql = executor();
+    const res = await provisionSchema(sql);
+    expect(res.mode).toBe("off");
+    expect(await hasConversations(sql)).toBe(false);
+  });
+});

--- a/backend/src/adapters/postgres/index.ts
+++ b/backend/src/adapters/postgres/index.ts
@@ -6,6 +6,7 @@ import type { AdapterCapability } from "../../persistence/index.js";
 
 export * from "./sql.js";
 export * from "./migrations.js";
+export * from "./schema.js";
 export * from "./conversation-store.js";
 export * from "./pg-executor.js";
 

--- a/backend/src/adapters/postgres/schema.ts
+++ b/backend/src/adapters/postgres/schema.ts
@@ -1,0 +1,107 @@
+/**
+ * Automatic schema provisioning — `docs/02-core-and-persistence.md`.
+ *
+ * A `SchemaManager` over the reversible migrations: it provisions a fresh database on startup
+ * (`auto`), logs the diff and refuses (`plan`), or leaves the schema to managed migrations
+ * (`off`, the default for Postgres). Forward-only and idempotent — running it twice is a no-op,
+ * so concurrent workers never double-provision.
+ */
+import { MIGRATIONS, type Migration } from "./migrations.js";
+import type { SqlExecutor } from "./sql.js";
+
+export type SchemaMode = "auto" | "plan" | "off";
+
+export type SchemaChange = {
+  readonly id: string;
+  readonly statements: readonly string[];
+};
+
+export interface SchemaManager {
+  currentVersion(): Promise<number>;
+  targetVersion(): number;
+  /** Pending changes — no side effects. */
+  plan(): Promise<readonly SchemaChange[]>;
+  /** Create/upgrade to the target version. Idempotent. */
+  apply(): Promise<void>;
+}
+
+const TRACKING = `CREATE TABLE IF NOT EXISTS schema_migrations (
+  id text PRIMARY KEY,
+  applied_at timestamptz NOT NULL DEFAULT now()
+)`;
+
+export const createSchemaManager = (
+  sql: SqlExecutor,
+  migrations: readonly Migration[] = MIGRATIONS,
+): SchemaManager => {
+  // Read-only: if the tracking table doesn't exist yet, nothing has been applied. `plan()` and
+  // `currentVersion()` therefore have no side effects; only `apply()` creates the table.
+  const appliedIds = async (): Promise<Set<string>> => {
+    try {
+      const rows = await sql.query<{ id: string }>(`SELECT id FROM schema_migrations`);
+      return new Set(rows.map((r) => r.id));
+    } catch {
+      return new Set<string>();
+    }
+  };
+  const pending = async (): Promise<Migration[]> => {
+    const done = await appliedIds();
+    return migrations.filter((m) => !done.has(m.id));
+  };
+
+  return {
+    async currentVersion() {
+      return (await appliedIds()).size;
+    },
+    targetVersion() {
+      return migrations.length;
+    },
+    async plan() {
+      return (await pending()).map((m) => ({ id: m.id, statements: m.up }));
+    },
+    async apply() {
+      await sql.query(TRACKING);
+      for (const m of await pending()) {
+        for (const stmt of m.up) await sql.query(stmt);
+        // ON CONFLICT DO NOTHING: two workers applying the same migration can't both record it.
+        await sql.query(`INSERT INTO schema_migrations (id) VALUES ($1) ON CONFLICT (id) DO NOTHING`, [m.id]);
+      }
+    },
+  };
+};
+
+export type ProvisionResult = {
+  readonly mode: SchemaMode;
+  readonly applied: readonly string[];
+  readonly planned: readonly SchemaChange[];
+};
+
+/**
+ * Startup provisioning per mode. `off` (Postgres default) leaves the schema to managed
+ * migrations; `plan` logs the pending diff and applies nothing; `auto` provisions.
+ */
+export const provisionSchema = async (
+  sql: SqlExecutor,
+  options: { readonly mode?: SchemaMode; readonly log?: (message: string) => void; readonly migrations?: readonly Migration[] } = {},
+): Promise<ProvisionResult> => {
+  const mode: SchemaMode = options.mode ?? "off";
+  const manager = createSchemaManager(sql, options.migrations);
+  const log = options.log ?? (() => {});
+
+  if (mode === "off") {
+    return { mode, applied: [], planned: [] };
+  }
+
+  const planned = await manager.plan();
+
+  if (mode === "plan") {
+    if (planned.length === 0) log("schema is up to date; no changes to apply");
+    else log(`schema plan — ${planned.length} pending migration(s): ${planned.map((c) => c.id).join(", ")}`);
+    return { mode, applied: [], planned };
+  }
+
+  // auto
+  await manager.apply();
+  if (planned.length) log(`provisioned schema: applied ${planned.map((c) => c.id).join(", ")}`);
+  return { mode, applied: planned.map((c) => c.id), planned };
+};


### PR DESCRIPTION
Closes #22

## Summary
SchemaManager over the Postgres migrations: auto/plan/off modes, version tracking, forward-only
and idempotent. Auto provisions a fresh DB; plan logs the diff and refuses; off is the default.

## Test plan (PGlite)
- auto: fresh DB → all migrations applied, currentVersion === targetVersion
- plan: returns/logs the diff, DB left untouched
- apply run twice is a no-op (idempotent — no double-provision)
- off: no-op
