### PR TITLE
Supabase adapter: RLS + Realtime (#21)

### DIFF
--- a/backend/src/__tests__/supabase-adapter.test.ts
+++ b/backend/src/__tests__/supabase-adapter.test.ts
@@ -1,0 +1,71 @@
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it } from "vitest";
+import {
+  applyRls,
+  createSupabaseConversationStore,
+  createSupabaseRealtimePublisher,
+  migrate,
+  setTenantContext,
+  type RealtimeBroadcaster,
+  type RunEvent,
+  type SqlExecutor,
+} from "../index.js";
+import { conversationStoreConformance } from "../testing/conformance.js";
+
+const pgliteSql = (db: PGlite): SqlExecutor => ({
+  query: (text, params) => db.query(text, params ? [...params] : undefined).then((r) => r.rows as never),
+});
+
+// The Supabase store is the Postgres store — it must pass the same conformance suite.
+const freshStore = () => {
+  let ready: Promise<SqlExecutor> | null = null;
+  const init = () =>
+    (ready ??= (async () => {
+      const sql = pgliteSql(new PGlite());
+      await migrate(sql);
+      return sql;
+    })());
+  const lazy: SqlExecutor = { async query(text, params) { return (await init()).query(text, params); } };
+  return createSupabaseConversationStore(lazy);
+};
+conversationStoreConformance(freshStore);
+
+describe("supabase RLS + realtime", () => {
+  it("RLS denies cross-tenant reads at the database, with no app-level WHERE", async () => {
+    const db = new PGlite();
+    const sql = pgliteSql(db);
+    await migrate(sql);
+    // Seed both tenants as the superuser (RLS is bypassed for the owner).
+    await db.query(
+      `INSERT INTO conversations (tenant_id, id, title, version, created_at, updated_at)
+       VALUES ('t1','c1','a',1,now(),now()), ('t2','c2','b',1,now(),now())`,
+    );
+    await applyRls(sql);
+    // Supabase connects as a non-superuser role; simulate that so RLS actually applies.
+    await db.exec(`CREATE ROLE app_user NOSUPERUSER; GRANT SELECT, INSERT, UPDATE, DELETE ON conversations TO app_user;`);
+
+    await setTenantContext(sql, "t1");
+    await db.exec(`SET ROLE app_user;`);
+    const seenAsT1 = await sql.query<{ id: string }>(`SELECT id FROM conversations`); // deliberately no WHERE
+    expect(seenAsT1.map((r) => r.id)).toEqual(["c1"]);
+
+    await db.exec(`RESET ROLE;`);
+    await setTenantContext(sql, "t2");
+    await db.exec(`SET ROLE app_user;`);
+    const seenAsT2 = await sql.query<{ id: string }>(`SELECT id FROM conversations`);
+    expect(seenAsT2.map((r) => r.id)).toEqual(["c2"]);
+  });
+
+  it("realtime publisher forwards run events to the broadcaster", async () => {
+    const calls: Array<{ channel: string; event: string; payload: unknown }> = [];
+    const broadcaster: RealtimeBroadcaster = {
+      send: (channel, event, payload) => {
+        calls.push({ channel, event, payload });
+      },
+    };
+    const publisher = createSupabaseRealtimePublisher(broadcaster);
+    const event = { type: "run.started", runId: "r1", sequence: 1, occurredAt: "t" } as unknown as RunEvent;
+    await publisher.publish("conversation:1", event);
+    expect(calls).toEqual([{ channel: "conversation:1", event: "run.started", payload: event }]);
+  });
+});

--- a/backend/src/adapters/supabase/index.ts
+++ b/backend/src/adapters/supabase/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Supabase adapter — Postgres store + RLS + Realtime. Supabase *is* Postgres, so the store is
+ * the PostgreSQL `ConversationStore`; this module adds the Supabase-specific RLS policies and a
+ * Realtime publisher, and advertises the extra capabilities.
+ */
+import type { AdapterCapability } from "../../persistence/index.js";
+
+export { createPostgresConversationStore as createSupabaseConversationStore } from "../postgres/conversation-store.js";
+export * from "./rls.js";
+export * from "./realtime.js";
+
+export const SUPABASE_CAPABILITIES: readonly AdapterCapability[] = [
+  "transactions",
+  "row-level-security",
+  "full-text-search",
+  "realtime",
+];

--- a/backend/src/adapters/supabase/realtime.ts
+++ b/backend/src/adapters/supabase/realtime.ts
@@ -1,0 +1,16 @@
+/**
+ * Supabase Realtime publisher for the `RealtimePublisher` port. The Supabase client is wired to
+ * a minimal `RealtimeBroadcaster` by the host app, so this module carries no client dependency.
+ */
+import type { RealtimePublisher, RunEvent } from "../../core/events.js";
+
+/** The app adapts a Supabase channel's `send` to this (`channel.send({ type, event, payload })`). */
+export interface RealtimeBroadcaster {
+  send(channel: string, event: string, payload: unknown): Promise<void> | void;
+}
+
+export const createSupabaseRealtimePublisher = (broadcaster: RealtimeBroadcaster): RealtimePublisher => ({
+  async publish(channel: string, event: RunEvent): Promise<void> {
+    await broadcaster.send(channel, event.type, event);
+  },
+});

--- a/backend/src/adapters/supabase/rls.ts
+++ b/backend/src/adapters/supabase/rls.ts
@@ -1,0 +1,27 @@
+/**
+ * Row-Level Security for Supabase — `docs/02` + `docs/11`.
+ *
+ * Enforces tenant isolation *at the database*, independent of any app-level `WHERE`. The policy
+ * predicate `tenant_id = current_setting('app.tenant_id')` is exactly the filter the
+ * authorization `scope()` produces (see `tenantRlsFilter`), so the two agree by construction.
+ * Supabase connects as a non-superuser role, so the policy applies (superusers bypass RLS).
+ */
+import type { SqlExecutor } from "../postgres/sql.js";
+
+export const RLS_STATEMENTS: readonly string[] = [
+  `ALTER TABLE conversations ENABLE ROW LEVEL SECURITY`,
+  `ALTER TABLE conversations FORCE ROW LEVEL SECURITY`,
+  `DROP POLICY IF EXISTS tenant_isolation ON conversations`,
+  `CREATE POLICY tenant_isolation ON conversations
+     USING (tenant_id = current_setting('app.tenant_id', true))
+     WITH CHECK (tenant_id = current_setting('app.tenant_id', true))`,
+];
+
+export const applyRls = async (sql: SqlExecutor): Promise<void> => {
+  for (const stmt of RLS_STATEMENTS) await sql.query(stmt);
+};
+
+/** Bind the current session to a tenant so RLS scopes every subsequent query. */
+export const setTenantContext = async (sql: SqlExecutor, tenantId: string): Promise<void> => {
+  await sql.query(`SELECT set_config('app.tenant_id', $1, false)`, [tenantId]);
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,3 +20,4 @@ export * from "./hitl/index.js";
 export * from "./persistence/index.js";
 export * from "./adapters/memory/index.js";
 export * from "./adapters/postgres/index.js";
+export * from "./adapters/supabase/index.js";


### PR DESCRIPTION
Closes #21

## Summary
Supabase adapter: reuses the Postgres store, adds DB-enforced RLS (tenant isolation independent
of app code, matching scope() from #23) and a Realtime publisher for the RealtimePublisher port.

## Test plan (PGlite)
- RLS: raw `SELECT * FROM conversations` after setTenantContext('t1') returns only t1 rows (DB-level)
- conformance suite green on the Supabase store
- realtime publisher forwards run events to the broadcaster
