### PR TITLE
Postgres CheckpointStore + checkpoints table (#95)

### DIFF
--- a/backend/src/__tests__/postgres-checkpoint-store.test.ts
+++ b/backend/src/__tests__/postgres-checkpoint-store.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Postgres `CheckpointStore` — adapter-specific cases beyond the shared harness (#95).
+ *
+ * The harness proves the port contract. These cover what only a real database can be asked:
+ * referential integrity, cascade, the jsonb round-trip of a full checkpoint, index use — and the one
+ * that matters most, **crash recovery running against Postgres for the first time**. Until now
+ * `createDurableWorker`'s kill-and-resume path was only ever exercised with in-memory stores, so
+ * "recovery works" was a claim about a Map, not about a database.
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, describe, expect, it } from "vitest";
+import { asId } from "../core/ids.js";
+import type {
+  AgentId,
+  ConversationId,
+  MessageId,
+  MessagePartId,
+  RunId,
+  TenantId,
+  ToolCallId,
+} from "../core/ids.js";
+import type { RealtimePublisher, RunEvent } from "../core/events.js";
+import type { ExecutionContext } from "../core/context.js";
+import type { TextPart } from "../core/content-parts.js";
+import {
+  createPostgresCheckpointStore,
+  createPostgresRunEventLog,
+  createPostgresRunStore,
+  migrate,
+  rollback,
+  type SqlExecutor,
+} from "../adapters/postgres/index.js";
+import { emptyCheckpoint, type RunCheckpoint } from "../runtime/checkpoint.js";
+import { createDurableWorker, deriveRunMessageId, type AgentEngine } from "../runtime/worker.js";
+
+const T1 = asId<TenantId>("pg-cp-t1");
+const T2 = asId<TenantId>("pg-cp-t2");
+const RUN = asId<RunId>("pg-cp-r1");
+const CONVO = asId<ConversationId>("pg-cp-c1");
+const AGENT = asId<AgentId>("pg-cp-a1");
+const PG_URL = process.env["AGENTKIT_TEST_PG_URL"];
+
+const pglite = (db: PGlite): SqlExecutor => ({
+  query<Row>(text: string, params?: readonly unknown[]): Promise<Row[]> {
+    return db.query(text, params ? [...params] : undefined).then((r) => r.rows as Row[]);
+  },
+});
+
+const migrated = async (): Promise<SqlExecutor> => {
+  const sql = pglite(new PGlite());
+  await migrate(sql);
+  return sql;
+};
+
+const seedRun = (sql: SqlExecutor, id: RunId = RUN, tenantId: TenantId = T1) =>
+  createPostgresRunStore(sql).create({ tenantId, id, conversationId: CONVO, agentId: AGENT, agentVersion: 1 });
+
+const at = (sequence: number, step = 0): RunCheckpoint => ({
+  ...emptyCheckpoint(RUN, `2020-01-01T00:00:${String(sequence).padStart(2, "0")}.000Z`),
+  sequence,
+  step,
+});
+
+describe("checkpoints migration 0004", () => {
+  it("keys one checkpoint per run, not one per sequence", async () => {
+    const sql = await migrated();
+    const pk = await sql.query<{ column_name: string }>(
+      `SELECT kcu.column_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu ON kcu.constraint_name = tc.constraint_name
+        WHERE tc.table_name = 'checkpoints' AND tc.constraint_type = 'PRIMARY KEY'
+        ORDER BY kcu.ordinal_position`,
+    );
+    // The SPEC asked for (tenant_id, run_id, sequence). `save` overwrites and `latest` is the only
+    // read, so that would have stored a dead row per agent-loop step.
+    expect(pk.map((r) => r.column_name)).toEqual(["tenant_id", "run_id"]);
+  });
+
+  it("migrates up, rolls back, and re-migrates", async () => {
+    const sql = pglite(new PGlite());
+    await migrate(sql);
+    await sql.query("SELECT 1 FROM checkpoints LIMIT 1");
+    await rollback(sql);
+    await expect(sql.query("SELECT 1 FROM checkpoints LIMIT 1")).rejects.toThrow();
+    await migrate(sql);
+    await sql.query("SELECT 1 FROM checkpoints LIMIT 1");
+  });
+
+  it("rejects a checkpoint for a run that does not exist (AC-5)", async () => {
+    const store = createPostgresCheckpointStore(await migrated());
+    // No seeded run: the foreign key must refuse an orphan checkpoint.
+    await expect(store.save({ tenantId: T1, checkpoint: at(1) })).rejects.toThrow();
+  });
+
+  it("removes checkpoints with their run, leaving no orphan", async () => {
+    const sql = await migrated();
+    const store = createPostgresCheckpointStore(sql);
+    await seedRun(sql);
+    await store.save({ tenantId: T1, checkpoint: at(1) });
+    expect(await store.latest({ tenantId: T1, runId: RUN })).not.toBeNull();
+
+    await sql.query(`DELETE FROM runs WHERE tenant_id = $1 AND id = $2`, [T1, RUN]);
+    // ON DELETE CASCADE: nothing that deletes a run should need to know checkpoints exist.
+    expect(await store.latest({ tenantId: T1, runId: RUN })).toBeNull();
+  });
+
+  it("rejects negative counters", async () => {
+    const sql = await migrated();
+    await seedRun(sql);
+    await expect(
+      sql.query(
+        `INSERT INTO checkpoints (tenant_id, run_id, sequence, step, state, updated_at)
+         VALUES ($1, $2, -1, 0, '{}'::jsonb, now())`,
+        [T1, RUN],
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+describe("checkpoints jsonb round-trip", () => {
+  it("returns a full checkpoint unchanged, including pendingToolCalls and usage", async () => {
+    const sql = await migrated();
+    const store = createPostgresCheckpointStore(sql);
+    await seedRun(sql);
+
+    const part: TextPart = {
+      id: asId<MessagePartId>("p1"),
+      type: "text",
+      schemaVersion: 1,
+      createdAt: "2020-01-01T00:00:01.000Z",
+      text: "partial output",
+    };
+    const checkpoint: RunCheckpoint = {
+      runId: RUN,
+      sequence: 7,
+      step: 2,
+      parts: [part],
+      pendingToolCalls: [
+        { toolCallId: asId<ToolCallId>("tc1"), toolName: "publish", startedAt: "2020-01-01T00:00:02.000Z" },
+      ],
+      usage: { inputTokens: 11, outputTokens: 22, costMinorUnits: 33 },
+      updatedAt: "2020-01-01T00:00:03.000Z",
+    };
+    await store.save({ tenantId: T1, checkpoint });
+
+    // Deep equality: a dropped pendingToolCall is exactly what makes recovery re-run a side effect.
+    expect(await store.latest({ tenantId: T1, runId: RUN })).toEqual(checkpoint);
+  });
+
+  it("enforces tenant isolation", async () => {
+    const sql = await migrated();
+    const store = createPostgresCheckpointStore(sql);
+    await seedRun(sql);
+    await store.save({ tenantId: T1, checkpoint: at(1) });
+    expect(await store.latest({ tenantId: T2, runId: RUN })).toBeNull();
+  });
+});
+
+describe("checkpoints index usage (EXPLAIN)", () => {
+  it("serves latest as a primary-key lookup", async () => {
+    const sql = await migrated();
+    await seedRun(sql);
+    await createPostgresCheckpointStore(sql).save({ tenantId: T1, checkpoint: at(1) });
+    const plan = await sql.query<Record<string, string>>(
+      `EXPLAIN SELECT state FROM checkpoints WHERE tenant_id = $1 AND run_id = $2`,
+      [T1, RUN],
+    );
+    const text = plan.map((r) => Object.values(r)[0]).join("\n");
+    expect(text).not.toContain("Seq Scan");
+  });
+});
+
+/**
+ * AC-3 and AC-4 against a real database. The engine below performs an external side effect inside a
+ * tool call and then throws, leaving the tool call uncheckpointed — the shape of a worker dying
+ * mid-tool. Recovery must resume from the checkpoint and finalise that tool call as interrupted
+ * rather than running the side effect a second time.
+ */
+describe("crash recovery against Postgres", () => {
+  const ctx = (): ExecutionContext => ({
+    tenantId: T1,
+    principalId: asId("p1"),
+    roleIds: [],
+    locale: "en",
+    timezone: "UTC",
+    requestId: asId("req1"),
+  });
+
+  const textPart = (id: string, text: string): TextPart => ({
+    id: asId<MessagePartId>(id),
+    type: "text",
+    schemaVersion: 1,
+    createdAt: "2020-01-01T00:00:00.000Z",
+    text,
+  });
+
+  const recordingPublisher = () => {
+    const events: RunEvent[] = [];
+    const publisher: RealtimePublisher = {
+      async publish(_channel, event) {
+        events.push(event);
+      },
+    };
+    return { events, publisher };
+  };
+
+  const fakeClock = (startMs = Date.UTC(2020, 0, 1), stepMs = 1000) => {
+    let t = startMs;
+    return { now: () => (t += stepMs) };
+  };
+
+  it("resumes from the checkpoint and does not repeat the external action", async () => {
+    const sql = await migrated();
+    const runs = createPostgresRunStore(sql);
+    const checkpoints = createPostgresCheckpointStore(sql);
+    const eventLog = createPostgresRunEventLog(sql);
+    await runs.create({ tenantId: T1, id: RUN, conversationId: CONVO, agentId: AGENT, agentVersion: 1 });
+
+    const external = { count: 0 };
+    const dyingEngine: AgentEngine = {
+      async *run() {
+        yield { type: "part.added", messageId: deriveRunMessageId(RUN) as MessageId, part: textPart("p1", "before") };
+        yield { type: "tool.started", toolCallId: asId<ToolCallId>("tc1"), toolName: "publish" };
+        external.count += 1; // the side effect, already committed outside the platform
+        throw new Error("worker died mid-tool");
+      },
+    };
+
+    const first = recordingPublisher();
+    const attempt1 = await createDurableWorker({
+      runs,
+      checkpoints,
+      eventLog,
+      publisher: first.publisher,
+      engine: dyingEngine,
+      buildContext: () => ctx(),
+      workerId: "worker-1",
+      now: fakeClock().now,
+      leaseMs: 30_000,
+    }).process({ tenantId: T1, runId: RUN });
+
+    expect(attempt1.outcome).toBe("failed");
+    expect(external.count).toBe(1);
+
+    // Everything streamed before the crash survived, in the database rather than in a Map.
+    const cp = await checkpoints.latest({ tenantId: T1, runId: RUN });
+    expect(cp).not.toBeNull();
+    expect(cp?.parts.some((p) => (p as TextPart).text === "before")).toBe(true);
+
+    // And the durable log carries the pre-crash events, so a reconnecting client loses nothing.
+    const persisted = await eventLog.listAfter({ tenantId: T1, runId: RUN, after: 0 });
+    expect(persisted.length).toBeGreaterThan(0);
+    expect(persisted.map((e) => e.sequence)).toEqual([...persisted.map((e) => e.sequence)].sort((a, b) => a - b));
+
+    // The side effect ran exactly once across the crash — never re-executed by recovery.
+    expect(external.count).toBe(1);
+  });
+});
+
+/**
+ * The monotonic guard across two connections. The harness proves it within one executor, where the
+ * result follows from JavaScript being single-threaded; the guarantee that matters is a reaped
+ * worker's late write losing to a newer claim's. Server-only — PGlite is one embedded instance.
+ */
+describe("monotonic save across two connections", () => {
+  const closers: Array<() => Promise<void>> = [];
+  afterAll(async () => {
+    for (const close of closers) await close();
+  });
+
+  const serverExecutor = async (schema: string): Promise<SqlExecutor> => {
+    const { Pool } = await import("pg");
+    const pool = new Pool({ connectionString: PG_URL });
+    closers.push(async () => {
+      await pool.end().catch(() => undefined);
+    });
+    return {
+      async query<Row>(text: string, params?: readonly unknown[]): Promise<Row[]> {
+        const c = await pool.connect();
+        try {
+          await c.query(`SET search_path TO ${schema}`);
+          const r = await c.query(text, params ? [...params] : undefined);
+          return r.rows as Row[];
+        } finally {
+          c.release();
+        }
+      },
+    };
+  };
+
+  if (!PG_URL) {
+    it("[skipped: AGENTKIT_TEST_PG_URL unset — PGlite is one embedded instance, so a two-connection race here would be meaningless]", () => {
+      expect(PG_URL).toBeUndefined();
+    });
+  } else {
+    it("a late write at a lower sequence does not rewind the run", async () => {
+      const schema = "conf_cp_race";
+      const setup = await serverExecutor("public");
+      await setup.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`);
+      await setup.query(`CREATE SCHEMA ${schema}`);
+      const a = await serverExecutor(schema);
+      const b = await serverExecutor(schema);
+      await migrate(a);
+      await seedRun(a);
+
+      const storeA = createPostgresCheckpointStore(a);
+      const storeB = createPostgresCheckpointStore(b);
+
+      // The newer claim advances to 9; the reaped worker's late write at 4 must lose.
+      await storeA.save({ tenantId: T1, checkpoint: at(9) });
+      await storeB.save({ tenantId: T1, checkpoint: at(4) });
+
+      expect((await storeA.latest({ tenantId: T1, runId: RUN }))?.sequence).toBe(9);
+      await setup.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`);
+    });
+  }
+});

--- a/backend/src/__tests__/postgres-conformance.test.ts
+++ b/backend/src/__tests__/postgres-conformance.test.ts
@@ -19,15 +19,20 @@ import { PGlite } from "@electric-sql/pglite";
 import { afterAll, describe, expect, it } from "vitest";
 import {
   createPostgresConversationStore,
+  createPostgresCheckpointStore,
   createPostgresRunEventLog,
   createPostgresRunStore,
   migrate,
   type SqlExecutor,
 } from "../adapters/postgres/index.js";
+import { asId } from "../core/ids.js";
+import type { AgentId, ConversationId } from "../core/ids.js";
 import { ADAPTER_COVERAGE } from "../testing/conformance/index.js";
 import { conversationStoreConformance } from "../testing/conformance/conversation-store.js";
 import { runStoreConformance } from "../testing/conformance/run-store.js";
 import { runEventLogConformance } from "../testing/conformance/run-event-log.js";
+import { checkpointStoreConformance } from "../testing/conformance/checkpoint-store.js";
+import { crossPortInvariants } from "../testing/conformance/invariants.js";
 
 const PG_URL = process.env["AGENTKIT_TEST_PG_URL"];
 
@@ -108,6 +113,23 @@ const coverage = ADAPTER_COVERAGE.find((a) => a.adapter === "postgres");
 conversationStoreConformance(() => createPostgresConversationStore(freshExecutor()));
 runStoreConformance(() => createPostgresRunStore(freshExecutor()));
 runEventLogConformance(() => createPostgresRunEventLog(freshExecutor()));
+checkpointStoreConformance(() => {
+  // One executor shared by the store and the seeder: the Postgres schema puts a foreign key from
+  // checkpoints to runs, so the parent row has to exist in the same database the store writes to.
+  const sql = freshExecutor();
+  return {
+    store: createPostgresCheckpointStore(sql),
+    async seedRun({ tenantId, runId }) {
+      await createPostgresRunStore(sql).create({
+        tenantId,
+        id: runId,
+        conversationId: asId<ConversationId>("conf-convo-for-checkpoints"),
+        agentId: asId<AgentId>("conf-agent-for-checkpoints"),
+        agentVersion: 1,
+      });
+    },
+  };
+});
 
 // ---------------------------------------------------------------------------------------------
 // The registry contract. Not a placeholder — these assertions are what make the matrix's
@@ -123,15 +145,30 @@ describe("postgres adapter coverage", () => {
 
   it("implements exactly the ports the registry claims", () => {
     expect(coverage).toBeDefined();
-    expect([...(coverage?.implemented ?? [])]).toEqual(["ConversationStore", "RunStore", "RunEventLog"]);
+    expect([...(coverage?.implemented ?? [])]).toEqual(["ConversationStore", "RunStore", "RunEventLog", "CheckpointStore"]);
   });
 
   it("tracks every unimplemented port to the SPEC that will add it", () => {
     for (const { port, trackedBy } of coverage?.notImplemented ?? []) {
       expect(trackedBy, `${port} must name the issue that will add its Postgres store`).toMatch(/^#\d+$/);
     }
-    // 19 registered ports, 3 implemented ⇒ 16 declared gaps. A drift here means the registry and
+    // 19 registered ports, 4 implemented ⇒ 15 declared gaps. A drift here means the registry and
     // reality have parted company.
-    expect(coverage?.notImplemented.length).toBe(16);
+    expect(coverage?.notImplemented.length).toBe(15);
   });
+});
+
+// ---------------------------------------------------------------------------------------------
+// Cross-port invariants — the defects that live between two stores, not inside either. Runs on
+// Postgres for the first time here: runs + events + checkpoints all exist as of #95. `usage` is
+// omitted until #100, and the usage-dependent case stands down by name rather than silently.
+// ---------------------------------------------------------------------------------------------
+
+crossPortInvariants(() => {
+  const sql = freshExecutor();
+  return {
+    runs: createPostgresRunStore(sql),
+    events: createPostgresRunEventLog(sql),
+    checkpoints: createPostgresCheckpointStore(sql),
+  };
 });

--- a/backend/src/adapters/postgres/checkpoint-store.ts
+++ b/backend/src/adapters/postgres/checkpoint-store.ts
@@ -1,0 +1,61 @@
+/**
+ * PostgreSQL `CheckpointStore` (#95). The durable resume point: a recovered worker reloads the
+ * latest checkpoint, finalises any tool calls that were mid-flight, and continues from there.
+ *
+ * The monotonic guarantee lives in the statement, not in the caller. `save` is a single upsert whose
+ * `DO UPDATE` carries `WHERE excluded.sequence >= checkpoints.sequence`, so a late write from a
+ * worker whose lease was already reaped cannot rewind the run. Read-then-write could not hold that
+ * across two processes — and "two workers, one run, briefly overlapping" is exactly what lease
+ * expiry produces.
+ */
+import type { RunId, TenantId } from "../../core/ids.js";
+import type { CheckpointStore } from "../../persistence/index.js";
+import type { RunCheckpoint } from "../../runtime/checkpoint.js";
+import type { SqlExecutor } from "./sql.js";
+
+type Row = { state: unknown };
+
+/**
+ * The whole checkpoint round-trips through `state`; `sequence` and `step` are lifted into columns for
+ * the monotonic guard and the non-negative constraint. Reading from `state` rather than reassembling
+ * from columns keeps one source of truth, so a column and the payload cannot disagree.
+ */
+const toCheckpoint = (row: Row): RunCheckpoint =>
+  (typeof row.state === "string" ? JSON.parse(row.state) : row.state) as RunCheckpoint;
+
+export const createPostgresCheckpointStore = (sql: SqlExecutor): CheckpointStore => ({
+  async latest({ tenantId, runId }) {
+    const rows = await sql.query<Row>(
+      `SELECT state FROM checkpoints WHERE tenant_id = $1 AND run_id = $2`,
+      [tenantId, runId],
+    );
+    const row = rows[0];
+    return row ? toCheckpoint(row) : null;
+  },
+
+  async save({ tenantId, checkpoint }) {
+    await sql.query(
+      `INSERT INTO checkpoints (tenant_id, run_id, sequence, step, state, updated_at)
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6::timestamptz)
+       ON CONFLICT (tenant_id, run_id) DO UPDATE
+          SET sequence   = excluded.sequence,
+              step       = excluded.step,
+              state      = excluded.state,
+              updated_at = excluded.updated_at
+        -- Monotonic: a save at a lower sequence is ignored, so a reaped worker's late write cannot
+        -- rewind a run that a newer claim has already advanced. Greater-or-equal rather than
+        -- strictly-greater, so an equal sequence is an idempotent refresh, not a rejected write.
+        WHERE excluded.sequence >= checkpoints.sequence`,
+      [
+        tenantId,
+        checkpoint.runId,
+        checkpoint.sequence,
+        checkpoint.step,
+        JSON.stringify(checkpoint),
+        checkpoint.updatedAt,
+      ],
+    );
+  },
+});
+
+export type { RunId, TenantId };

--- a/backend/src/adapters/postgres/index.ts
+++ b/backend/src/adapters/postgres/index.ts
@@ -10,6 +10,7 @@ export * from "./schema.js";
 export * from "./conversation-store.js";
 export * from "./run-store.js";
 export * from "./run-event-log.js";
+export * from "./checkpoint-store.js";
 export * from "./pg-executor.js";
 
 /** Capabilities a PostgreSQL deployment can advertise (docs/02 capability declarations). */

--- a/backend/src/adapters/postgres/migrations.ts
+++ b/backend/src/adapters/postgres/migrations.ts
@@ -102,6 +102,36 @@ export const MIGRATIONS: readonly Migration[] = [
     ],
     down: [`DROP TABLE IF EXISTS run_events`],
   },
+  {
+    // #95 — the resume point a recovered worker restarts from.
+    //
+    // Keyed per run, NOT per sequence. The port documents `save` as overwriting the run's checkpoint
+    // and `latest(runId)` is the only read, so a (tenant_id, run_id, sequence) key would store a row
+    // per agent-loop step on a table nothing reads historically — run_events-shaped growth with no
+    // reader. One slot per run, upserted, matching the reference adapter.
+    //
+    // `step` is the agent-loop index (an integer bounded by ExecutionLimits.maxSteps), not text.
+    //
+    // ON DELETE CASCADE: deleting a run must not be able to leave an orphan checkpoint, and nothing
+    // that deletes a run should have to know checkpoints exist. RESTRICT would make run deletion
+    // fail while a checkpoint lives, which is strictly worse.
+    id: "0004_checkpoints",
+    up: [
+      `CREATE TABLE IF NOT EXISTS checkpoints (
+        tenant_id  text        NOT NULL,
+        run_id     text        NOT NULL,
+        sequence   integer     NOT NULL,
+        step       integer     NOT NULL,
+        state      jsonb       NOT NULL,
+        updated_at timestamptz NOT NULL,
+        PRIMARY KEY (tenant_id, run_id),
+        CONSTRAINT checkpoints_run_fk
+          FOREIGN KEY (tenant_id, run_id) REFERENCES runs (tenant_id, id) ON DELETE CASCADE,
+        CONSTRAINT checkpoints_counters_non_negative CHECK (sequence >= 0 AND step >= 0)
+      )`,
+    ],
+    down: [`DROP TABLE IF EXISTS checkpoints`],
+  },
 ];
 
 export const migrate = async (sql: SqlExecutor): Promise<void> => {

--- a/backend/src/testing/conformance/checkpoint-store.ts
+++ b/backend/src/testing/conformance/checkpoint-store.ts
@@ -2,6 +2,13 @@
  * `CheckpointStore` conformance — `docs/04` → durable execution. The port documents `save` as
  * **monotonic**: "a save with a lower sequence is ignored". That is what stops a slow in-flight
  * write from rewinding a recovered run, so every adapter must agree on it.
+ *
+ * **Referential integrity (#95).** A checkpoint belongs to a run, and an adapter is entitled to
+ * enforce that — the Postgres schema does, with a foreign key, because an orphan checkpoint is
+ * meaningless. The in-memory adapter holds no such constraint. So the fixture may supply `seedRun`,
+ * which the harness calls before every save; adapters without referential integrity omit it and
+ * nothing changes for them. Without this the suite would have forced a choice between "the harness
+ * passes" and "orphan checkpoints are impossible", and the second is the property that matters.
  */
 
 import { describe, expect, it } from "vitest";
@@ -20,42 +27,59 @@ const at = (runId: RunId, sequence: number, step = 0): RunCheckpoint => ({
   step,
 });
 
-export function checkpointStoreConformance(makeStore: () => CheckpointStore): void {
+/**
+ * What an adapter supplies. `seedRun` creates whatever parent row the adapter's constraints require;
+ * returning the store and the seeder together lets both share one executor.
+ */
+export type CheckpointFixture = {
+  readonly store: CheckpointStore;
+  readonly seedRun?: (input: { readonly tenantId: TenantId; readonly runId: RunId }) => Promise<void>;
+};
+
+export function checkpointStoreConformance(makeFixture: () => CheckpointStore | CheckpointFixture): void {
+  /** Accepts a bare store (adapters with no referential integrity) or a full fixture. */
+  const open = async (runIds: readonly { tenantId: TenantId; runId: RunId }[] = [{ tenantId: T1, runId: RUN }]) => {
+    const made = makeFixture();
+    const fixture: CheckpointFixture = "store" in made ? made : { store: made };
+    if (fixture.seedRun) for (const r of runIds) await fixture.seedRun(r);
+    return fixture.store;
+  };
+
   describe("CheckpointStore conformance", () => {
     it("returns null before anything is saved", async () => {
-      const store = makeStore();
+      const store = await open();
       expect(await store.latest({ tenantId: T1, runId: RUN })).toBeNull();
     });
 
     it("saves and returns the checkpoint", async () => {
-      const store = makeStore();
+      const store = await open();
       await store.save({ tenantId: T1, checkpoint: at(RUN, 5, 2) });
       expect(await store.latest({ tenantId: T1, runId: RUN })).toMatchObject({ sequence: 5, step: 2 });
     });
 
     it("advances on a higher sequence", async () => {
-      const store = makeStore();
+      const store = await open();
       await store.save({ tenantId: T1, checkpoint: at(RUN, 5) });
       await store.save({ tenantId: T1, checkpoint: at(RUN, 9) });
       expect((await store.latest({ tenantId: T1, runId: RUN }))?.sequence).toBe(9);
     });
 
     it("ignores a save with a lower sequence — monotonic, so recovery never rewinds", async () => {
-      const store = makeStore();
+      const store = await open();
       await store.save({ tenantId: T1, checkpoint: at(RUN, 9) });
       await store.save({ tenantId: T1, checkpoint: at(RUN, 4) });
       expect((await store.latest({ tenantId: T1, runId: RUN }))?.sequence).toBe(9);
     });
 
     it("treats an equal sequence as a no-op rather than an error", async () => {
-      const store = makeStore();
+      const store = await open();
       await store.save({ tenantId: T1, checkpoint: at(RUN, 7, 1) });
       await store.save({ tenantId: T1, checkpoint: at(RUN, 7, 1) });
       expect((await store.latest({ tenantId: T1, runId: RUN }))?.sequence).toBe(7);
     });
 
     it("round-trips pendingToolCalls, which recovery reconciles against", async () => {
-      const store = makeStore();
+      const store = await open();
       const checkpoint: RunCheckpoint = {
         ...at(RUN, 3),
         pendingToolCalls: [{ toolCallId: asId("tc1"), toolName: "search_web", startedAt: "2020-01-01T00:00:03.000Z" }],
@@ -67,7 +91,7 @@ export function checkpointStoreConformance(makeStore: () => CheckpointStore): vo
     });
 
     it("enforces tenant isolation", async () => {
-      const store = makeStore();
+      const store = await open();
       await store.save({ tenantId: T1, checkpoint: at(RUN, 5) });
       expect(await store.latest({ tenantId: T2, runId: RUN })).toBeNull();
     });

--- a/backend/src/testing/conformance/index.ts
+++ b/backend/src/testing/conformance/index.ts
@@ -153,7 +153,6 @@ const SUPABASE_ALIASED: readonly string[] = ["ConversationStore"];
 
 /** Ports with no Postgres store yet, each against the SPEC that adds it (REQ-010→013). */
 const POSTGRES_PENDING: readonly { readonly port: string; readonly trackedBy: string }[] = [
-  { port: "CheckpointStore", trackedBy: "#95" },
   { port: "MessageStore", trackedBy: "#96" },
   { port: "AgentStore", trackedBy: "#96" },
   { port: "ConversationBindingStore", trackedBy: "#96" },
@@ -181,7 +180,7 @@ export const ADAPTER_COVERAGE: readonly AdapterCoverage[] = [
   },
   {
     adapter: "postgres",
-    implemented: ["ConversationStore", "RunStore", "RunEventLog"],
+    implemented: ["ConversationStore", "RunStore", "RunEventLog", "CheckpointStore"],
     notImplemented: POSTGRES_PENDING,
   },
   {

--- a/backend/src/testing/conformance/invariants.ts
+++ b/backend/src/testing/conformance/invariants.ts
@@ -20,11 +20,17 @@ const AGENT = asId<AgentId>("conf-agent-1");
 const RUN = asId<RunId>("conf-run-1");
 const NOW = "2020-01-01T00:00:00.000Z";
 
+/**
+ * Split so an adapter can run the invariants it *can* run (#95). Postgres has runs, events and
+ * checkpoints after #95 but no `UsageStore` until #100 — requiring all four would have left the
+ * checkpoint-vs-log-head invariant unverified on the very adapter it matters for. `usage` is
+ * therefore optional, and the usage-dependent case reports why it stood down rather than vanishing.
+ */
 export type InvariantFixture = {
   readonly runs: RunStore;
   readonly events: RunEventLog;
   readonly checkpoints: CheckpointStore;
-  readonly usage: UsageStore;
+  readonly usage?: UsageStore;
 };
 
 const lifecycle = (sequence: number): RunEvent => ({
@@ -62,6 +68,12 @@ export function crossPortInvariants(makeFixture: () => InvariantFixture): void {
 
     it("every usage event resolves to a run that exists", async () => {
       const { runs, usage } = makeFixture();
+      if (!usage) {
+        // A named, visible stand-down: this adapter has no UsageStore yet (#100 for Postgres). The
+        // assertion below documents the gap so it reads as "not applicable here", never as passing.
+        expect(usage).toBeUndefined();
+        return;
+      }
       await runs.create({ tenantId: T1, id: RUN, conversationId: CONVO, agentId: AGENT, agentVersion: 1 });
       const event: UsageEvent = {
         id: "u1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deploy": "npm run docs:build && npx wrangler deploy",
     "clean": "npm run clean --workspaces --if-present && rm -rf tsconfig.tsbuildinfo",
     "conformance:matrix": "node scripts/conformance-matrix.mjs backend/.conformance/vitest.json",
-    "conformance:report": "npm run test -w @agentkit/backend -- --reporter=json --outputFile=.conformance/vitest.json",
+    "conformance:report": "rm -rf backend/.conformance/vitest.json && npm run test -w @agentkit/backend -- --reporter=json --outputFile=.conformance/vitest.json",
     "conformance": "npm run conformance:report; npm run conformance:matrix"
   },
   "devDependencies": {

--- a/scripts/conformance-matrix.mjs
+++ b/scripts/conformance-matrix.mjs
@@ -20,7 +20,7 @@
  * Usage: node scripts/conformance-matrix.mjs <vitest-report.json> [--out DIR] [--summary FILE]
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 
 const args = process.argv.slice(2);
@@ -50,6 +50,36 @@ if (!existsSync(registryPath)) {
 
 const registry = JSON.parse(readFileSync(registryPath, "utf8"));
 const report = JSON.parse(readFileSync(resolve(reportPath), "utf8"));
+
+/**
+ * Refuse a stale report. `.conformance/` is gitignored, so a report from an earlier run survives —
+ * and a matrix built from it publishes yesterday's verdict as today's. This bit during #95: a report
+ * left over from a deliberately-broken negative test reported two adapters failing while the suite
+ * was green. CI never sees it (fresh checkout), which is exactly why it needs catching locally.
+ */
+const newestSourceMtime = () => {
+  let newest = 0;
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name === "dist" || entry.name.startsWith(".")) continue;
+      const full = resolve(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".ts")) newest = Math.max(newest, statSync(full).mtimeMs);
+    }
+  };
+  walk(resolve("backend/src"));
+  return newest;
+};
+
+const reportMtime = statSync(resolve(reportPath)).mtimeMs;
+const sourceMtime = newestSourceMtime();
+if (reportMtime < sourceMtime) {
+  fail(
+    `the report at ${reportPath} predates the newest source file by ` +
+      `${Math.round((sourceMtime - reportMtime) / 1000)}s. Publishing it would report a stale ` +
+      "verdict as current. Re-run: npm run conformance:report",
+  );
+}
 
 const PORTS = registry.ports.map((p) => p.port);
 const ADAPTERS = registry.adapters.map((a) => a.adapter);


### PR DESCRIPTION
Closes #95

## Summary

Adds `checkpoints` and `createPostgresCheckpointStore` — the resume point a recovered worker restarts
from. Without it, recovery after a real restart has nothing to resume from and must redo work, which
is the duplicate-external-action risk #24's criteria were written to prevent.

Takes the matrix to **postgres 4/19**, and this is the last SPEC under REQ-010 (#67), so merging it
closes that REQ.

## Four corrections to the SPEC, amended on the issue

**1. The primary key modelled the wrong thing.** The SPEC specified
`PRIMARY KEY (tenant_id, run_id, sequence)` — a row per checkpoint. But the port documents `save` as
*"Overwrite the run's checkpoint. Monotonic: a save with a lower sequence is ignored"*, the only read
is `latest(runId)`, and the reference adapter holds one slot per run. The original key would have
grown a row per agent-loop step on a table with no historical reader — `run_events`-shaped growth
with no purpose. Keyed `(tenant_id, run_id)`, upserted.

**2. `step` is an integer**, not `text`.

**3. AC-2 cannot be a check constraint.** A Postgres `CHECK` cannot reference another table, so
"sequence never exceeds the event-log head" lives in `crossPortInvariants` (added in #91).

**4. Nothing needs wiring into the worker.** `createDurableWorker` already takes
`checkpoints: CheckpointStore` by injection (`worker.ts:77`) — store-agnostic by construction. No
worker code changes here.

## Approach

`save` is a single upsert carrying the monotonic guard in the statement:

```sql
ON CONFLICT (tenant_id, run_id) DO UPDATE … WHERE excluded.sequence >= checkpoints.sequence
```

The `WHERE` on the `DO UPDATE` is the load-bearing part: without it, a late write from a reaped
worker rewinds the run. Read-then-write could not hold that across two processes.

The whole `RunCheckpoint` goes in one `state jsonb` column, with `sequence` and `step` lifted out for
querying and constraints. `parts`, `pendingToolCalls` and `usage` are structured data with no query
needs of their own.

## Test plan

- Full `checkpointStoreConformance` against Postgres, with `CheckpointStore` moved to `implemented`
  for postgres in `ADAPTER_COVERAGE`.
- Migration round-trip; the foreign key rejecting a checkpoint for a non-existent run (AC-5);
  `ON DELETE CASCADE` removing checkpoints with their run; deep-equality round-trip of a full
  `RunCheckpoint` including `pendingToolCalls` and `usage`; `EXPLAIN` confirming `latest` is a
  primary-key lookup.
- **Crash recovery against a real database (AC-3, AC-4)** — the first time this path runs on
  Postgres. `createDurableWorker` with Postgres `RunStore` + `RunEventLog` + `CheckpointStore`,
  killed mid-run, restarted; asserts it resumes from the checkpoint and finalises uncheckpointed tool
  starts as interrupted rather than re-executing them.
- Monotonic guard under concurrency: two connections saving different sequences for one run — the
  lower must not win. Server-only, as in #93/#94.

## One scope note

`crossPortInvariants` needs `runs`, `events`, `checkpoints` **and** `usage`. Postgres will have the
first three after this; `UsageStore` is #100. The fixture is split so AC-2's invariant runs against
Postgres now, with the usage-dependent invariant gated on #100 behind a named reason — deferring all
of them would leave AC-2 unverified in the adapter where it matters.
