### PR TITLE
Postgres MessageStore, AgentStore and ConversationBindingStore (#96)

### DIFF
--- a/backend/src/__tests__/postgres-conformance.test.ts
+++ b/backend/src/__tests__/postgres-conformance.test.ts
@@ -19,20 +19,26 @@ import { PGlite } from "@electric-sql/pglite";
 import { afterAll, describe, expect, it } from "vitest";
 import {
   createPostgresConversationStore,
+  createPostgresAgentStore,
   createPostgresCheckpointStore,
+  createPostgresConversationBindingStore,
+  createPostgresMessageStore,
   createPostgresRunEventLog,
   createPostgresRunStore,
   migrate,
   type SqlExecutor,
 } from "../adapters/postgres/index.js";
 import { asId } from "../core/ids.js";
-import type { AgentId, ConversationId } from "../core/ids.js";
+import type { AgentId, ConversationId, MessageId, MessagePartId } from "../core/ids.js";
+import type { AgentManifest } from "../agents/index.js";
 import { ADAPTER_COVERAGE } from "../testing/conformance/index.js";
 import { conversationStoreConformance } from "../testing/conformance/conversation-store.js";
 import { runStoreConformance } from "../testing/conformance/run-store.js";
 import { runEventLogConformance } from "../testing/conformance/run-event-log.js";
 import { checkpointStoreConformance } from "../testing/conformance/checkpoint-store.js";
 import { crossPortInvariants } from "../testing/conformance/invariants.js";
+import { agentStoreConformance, messageStoreConformance } from "../testing/conformance/records.js";
+import { conversationBindingStoreConformance } from "../testing/conformance/session-state.js";
 
 const PG_URL = process.env["AGENTKIT_TEST_PG_URL"];
 
@@ -104,6 +110,22 @@ afterAll(async () => {
   for (const close of closers) await close();
 });
 
+/** Minimal valid manifest for the AgentStore harness — the store round-trips it as opaque jsonb. */
+const agentManifest = (id: string, version: number): AgentManifest => ({
+  id,
+  version,
+  name: `agent ${id} v${version}`,
+  description: "conformance fixture",
+  instructions: "be useful",
+  modelPolicy: { preferred: "claude-opus-5" },
+  responseFormat: { kind: "text" },
+  toolPolicy: { allow: [] },
+  skillPolicy: { allow: [] },
+  authorizationPolicyId: "default",
+  contextProviderIds: [],
+  limits: { maxSteps: 4, maxToolCalls: 8, maxWallClockMs: 60_000 },
+});
+
 const coverage = ADAPTER_COVERAGE.find((a) => a.adapter === "postgres");
 
 // ---------------------------------------------------------------------------------------------
@@ -113,6 +135,57 @@ const coverage = ADAPTER_COVERAGE.find((a) => a.adapter === "postgres");
 conversationStoreConformance(() => createPostgresConversationStore(freshExecutor()));
 runStoreConformance(() => createPostgresRunStore(freshExecutor()));
 runEventLogConformance(() => createPostgresRunEventLog(freshExecutor()));
+// A conversation must exist before a message or binding can reference it (foreign keys, #96), so
+// each of these seeds its parent through the shared `parents` helper.
+messageStoreConformance(
+  () => {
+    const sql = freshExecutor();
+    return {
+      store: createPostgresMessageStore(sql),
+      async seedConversation({ tenantId, conversationId }) {
+        await createPostgresConversationStore(sql).create({ tenantId, id: conversationId, title: "for messages" });
+      },
+    };
+  },
+  async (store, { tenantId, conversationId, count }) => {
+    const s = store as ReturnType<typeof createPostgresMessageStore>;
+    for (let n = 0; n < count; n += 1) {
+      await s.append(tenantId, {
+        id: asId<MessageId>(`m${n}`),
+        conversationId,
+        role: "user",
+        parts: [
+          {
+            id: asId<MessagePartId>(`p${n}`),
+            type: "text",
+            schemaVersion: 1,
+            createdAt: `2020-01-01T00:00:${String(n).padStart(2, "0")}.000Z`,
+            text: `message ${n}`,
+          },
+        ],
+        createdAt: `2020-01-01T00:00:${String(n).padStart(2, "0")}.000Z`,
+      });
+    }
+  },
+);
+
+agentStoreConformance(
+  () => createPostgresAgentStore(freshExecutor()),
+  async (store, { tenantId, agentId, version }) => {
+    await (store as ReturnType<typeof createPostgresAgentStore>).put(tenantId, agentManifest(agentId, version));
+  },
+);
+
+conversationBindingStoreConformance(() => {
+  const sql = freshExecutor();
+  return {
+    store: createPostgresConversationBindingStore(sql),
+    async seedConversation({ tenantId, conversationId }) {
+      await createPostgresConversationStore(sql).create({ tenantId, id: conversationId, title: "for binding" });
+    },
+  };
+});
+
 checkpointStoreConformance(() => {
   // One executor shared by the store and the seeder: the Postgres schema puts a foreign key from
   // checkpoints to runs, so the parent row has to exist in the same database the store writes to.
@@ -145,16 +218,24 @@ describe("postgres adapter coverage", () => {
 
   it("implements exactly the ports the registry claims", () => {
     expect(coverage).toBeDefined();
-    expect([...(coverage?.implemented ?? [])]).toEqual(["ConversationStore", "RunStore", "RunEventLog", "CheckpointStore"]);
+    expect([...(coverage?.implemented ?? [])]).toEqual([
+      "ConversationStore",
+      "RunStore",
+      "RunEventLog",
+      "CheckpointStore",
+      "MessageStore",
+      "AgentStore",
+      "ConversationBindingStore",
+    ]);
   });
 
   it("tracks every unimplemented port to the SPEC that will add it", () => {
     for (const { port, trackedBy } of coverage?.notImplemented ?? []) {
       expect(trackedBy, `${port} must name the issue that will add its Postgres store`).toMatch(/^#\d+$/);
     }
-    // 19 registered ports, 4 implemented ⇒ 15 declared gaps. A drift here means the registry and
+    // 19 registered ports, 7 implemented ⇒ 12 declared gaps. A drift here means the registry and
     // reality have parted company.
-    expect(coverage?.notImplemented.length).toBe(15);
+    expect(coverage?.notImplemented.length).toBe(12);
   });
 });
 

--- a/backend/src/__tests__/postgres-message-agent-binding.test.ts
+++ b/backend/src/__tests__/postgres-message-agent-binding.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Postgres `MessageStore` / `AgentStore` / `ConversationBindingStore` — adapter-specific cases
+ * beyond the shared harnesses (#96).
+ *
+ * The headline one is paging under concurrent inserts. The harness pages a static conversation, which
+ * a naive `OFFSET` pager passes just as happily as a keyset one — so it cannot distinguish them. AC-2
+ * is about a conversation still being written to while a client reads it, and that needs live inserts
+ * between pages.
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it } from "vitest";
+import { asId } from "../core/ids.js";
+import type {
+  AgentId,
+  ConversationId,
+  MessageId,
+  MessagePartId,
+  TenantId,
+} from "../core/ids.js";
+import type { Message } from "../core/content-parts.js";
+import type { AgentManifest } from "../agents/index.js";
+import {
+  createPostgresAgentStore,
+  createPostgresConversationBindingStore,
+  createPostgresConversationStore,
+  createPostgresMessageStore,
+  migrate,
+  rollback,
+  type SqlExecutor,
+} from "../adapters/postgres/index.js";
+
+const T1 = asId<TenantId>("pg-msg-t1");
+const T2 = asId<TenantId>("pg-msg-t2");
+const C1 = asId<ConversationId>("pg-msg-c1");
+const AGENT = asId<AgentId>("pg-msg-a1");
+
+const pglite = (db: PGlite): SqlExecutor => ({
+  query<Row>(text: string, params?: readonly unknown[]): Promise<Row[]> {
+    return db.query(text, params ? [...params] : undefined).then((r) => r.rows as Row[]);
+  },
+});
+
+const migrated = async (): Promise<SqlExecutor> => {
+  const sql = pglite(new PGlite());
+  await migrate(sql);
+  return sql;
+};
+
+const withConversation = async (): Promise<SqlExecutor> => {
+  const sql = await migrated();
+  await createPostgresConversationStore(sql).create({ tenantId: T1, id: C1, title: "thread" });
+  return sql;
+};
+
+/** `n` zero-padded so lexical and numeric order agree — the ordering under test is the store's. */
+const msg = (n: number, overrides: Partial<Message> = {}): Message => ({
+  id: asId<MessageId>(`m${String(n).padStart(4, "0")}`),
+  conversationId: C1,
+  role: "user",
+  parts: [
+    {
+      id: asId<MessagePartId>(`p${String(n).padStart(4, "0")}`),
+      type: "text",
+      schemaVersion: 1,
+      createdAt: "2020-01-01T00:00:00.000Z",
+      text: `body ${n}`,
+    },
+  ],
+  // All rows share one timestamp on purpose: it forces the `id` tiebreak to carry the ordering,
+  // which is precisely the case a timestamp-only cursor gets wrong.
+  createdAt: "2020-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("migration 0005", () => {
+  it("keys agents per version, so an old version stays resolvable", async () => {
+    const sql = await migrated();
+    const pk = await sql.query<{ column_name: string }>(
+      `SELECT kcu.column_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu ON kcu.constraint_name = tc.constraint_name
+        WHERE tc.table_name = 'agents' AND tc.constraint_type = 'PRIMARY KEY'
+        ORDER BY kcu.ordinal_position`,
+    );
+    // The SPEC gave no primary key at all; findByVersion({agentId, version}) implies this one.
+    expect(pk.map((r) => r.column_name)).toEqual(["tenant_id", "id", "version"]);
+  });
+
+  it("stores the binding policy the SPEC omitted", async () => {
+    const sql = await migrated();
+    const cols = await sql.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'conversation_bindings'`,
+    );
+    expect(cols.map((c) => c.column_name)).toContain("agent_version_policy");
+  });
+
+  it("refuses a pinned binding with no version", async () => {
+    const sql = await withConversation();
+    // The pair must agree: 'pinned' without a version is a binding that cannot be honoured.
+    await expect(
+      sql.query(
+        `INSERT INTO conversation_bindings
+           (tenant_id, conversation_id, agent_id, agent_version_policy, agent_version, bound_at)
+         VALUES ($1, $2, $3, 'pinned', NULL, now())`,
+        [T1, C1, AGENT],
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("refuses an unknown version policy", async () => {
+    const sql = await withConversation();
+    await expect(
+      sql.query(
+        `INSERT INTO conversation_bindings
+           (tenant_id, conversation_id, agent_id, agent_version_policy, agent_version, bound_at)
+         VALUES ($1, $2, $3, 'whenever', NULL, now())`,
+        [T1, C1, AGENT],
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("migrates up, rolls back, and re-migrates", async () => {
+    const sql = pglite(new PGlite());
+    await migrate(sql);
+    for (const t of ["messages", "agents", "conversation_bindings"]) {
+      await sql.query(`SELECT 1 FROM ${t} LIMIT 1`);
+    }
+    await rollback(sql);
+    await expect(sql.query("SELECT 1 FROM messages LIMIT 1")).rejects.toThrow();
+    await migrate(sql);
+    await sql.query("SELECT 1 FROM messages LIMIT 1");
+  });
+
+  it("removes messages and bindings with their conversation", async () => {
+    const sql = await withConversation();
+    const messages = createPostgresMessageStore(sql);
+    const bindings = createPostgresConversationBindingStore(sql);
+    await messages.append(T1, msg(1));
+    await bindings.bind({ tenantId: T1, conversationId: C1, agentId: AGENT, agentVersionPolicy: "latest" });
+
+    await sql.query(`DELETE FROM conversations WHERE tenant_id = $1 AND id = $2`, [T1, C1]);
+
+    expect((await messages.listByConversation({ tenantId: T1, conversationId: C1, limit: 10 })).items).toHaveLength(0);
+    expect(await bindings.get({ tenantId: T1, conversationId: C1 })).toBeNull();
+  });
+
+  it("refuses a message for a conversation that does not exist", async () => {
+    const sql = await migrated();
+    await expect(createPostgresMessageStore(sql).append(T1, msg(1))).rejects.toThrow();
+  });
+});
+
+describe("message round-trip and validation", () => {
+  it("preserves a mixed-part message under deep equality", async () => {
+    const sql = await withConversation();
+    const store = createPostgresMessageStore(sql);
+    const mixed = msg(1, {
+      role: "assistant",
+      parts: [
+        {
+          id: asId<MessagePartId>("p-text"),
+          type: "text",
+          schemaVersion: 1,
+          createdAt: "2020-01-01T00:00:01.000Z",
+          text: "here is the result",
+        },
+        {
+          id: asId<MessagePartId>("p-tool"),
+          type: "tool-result",
+          schemaVersion: 1,
+          createdAt: "2020-01-01T00:00:02.000Z",
+          toolCallId: asId("tc1"),
+          toolName: "search_web",
+          // The field is `output`, not `result`, and `truncated` is required — the spill flag that
+          // says whether the payload is inline or referenced. Getting this wrong first time is what
+          // the read-side validation is for.
+          output: { ok: true, hits: 3 },
+          truncated: false,
+        },
+      ] as Message["parts"],
+    });
+    await store.append(T1, mixed);
+    // Deep equality: a dropped nested field inside a tool result is exactly the loss a shallower
+    // assertion misses.
+    expect(await store.findById({ tenantId: T1, id: mixed.id })).toEqual(mixed);
+  });
+
+  it("raises a typed error naming the message when parts are corrupt (AC-5)", async () => {
+    const sql = await withConversation();
+    const store = createPostgresMessageStore(sql);
+    await sql.query(
+      `INSERT INTO messages (tenant_id, id, conversation_id, role, parts, created_at)
+       VALUES ($1, 'bad-msg', $2, 'user', '[{"nonsense": true}]'::jsonb, now())`,
+      [T1, C1],
+    );
+    // The id has to appear in the message, or a bad row means grepping a table to find it.
+    await expect(store.findById({ tenantId: T1, id: asId<MessageId>("bad-msg") })).rejects.toThrow(/bad-msg/);
+  });
+
+  it("raises rather than returning a half-built message when parts is not an array", async () => {
+    const sql = await withConversation();
+    const store = createPostgresMessageStore(sql);
+    await sql.query(
+      `INSERT INTO messages (tenant_id, id, conversation_id, role, parts, created_at)
+       VALUES ($1, 'obj-msg', $2, 'user', '{"not": "an array"}'::jsonb, now())`,
+      [T1, C1],
+    );
+    await expect(store.findById({ tenantId: T1, id: asId<MessageId>("obj-msg") })).rejects.toThrow(/obj-msg/);
+  });
+});
+
+/**
+ * AC-2, properly. The harness pages a conversation nobody is writing to, which an `OFFSET` pager
+ * survives — so this inserts between pages, which is what a live conversation actually does.
+ */
+describe("paging under concurrent inserts (AC-2)", () => {
+  it("pages a 500-message conversation with no duplicate and no skip while more arrive", async () => {
+    const sql = await withConversation();
+    const store = createPostgresMessageStore(sql);
+    for (let n = 0; n < 500; n += 1) await store.append(T1, msg(n));
+
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    let inserted = 500;
+    for (let page = 0; page < 12; page += 1) {
+      const result = await store.listByConversation({
+        tenantId: T1,
+        conversationId: C1,
+        limit: 40,
+        ...(cursor === undefined ? {} : { cursor }),
+      });
+      seen.push(...result.items.map((m) => m.id));
+      // A new message lands mid-pagination, exactly as it would in a live thread.
+      await store.append(T1, msg(inserted));
+      inserted += 1;
+      if (result.nextCursor === undefined) break;
+      cursor = result.nextCursor;
+    }
+
+    // No id appears twice: an OFFSET pager would repeat rows as earlier inserts shift the window.
+    expect(new Set(seen).size).toBe(seen.length);
+    // And the run we walked is contiguous in the store's order — nothing was stepped over.
+    const sorted = [...seen].sort();
+    expect(seen).toEqual(sorted);
+  });
+
+  it("serves the paging query from its index", async () => {
+    const sql = await withConversation();
+    await createPostgresMessageStore(sql).append(T1, msg(1));
+    const plan = await sql.query<Record<string, string>>(
+      `EXPLAIN SELECT * FROM messages
+        WHERE tenant_id = $1 AND conversation_id = $2 AND (created_at, id) > ($3::timestamptz, $4)
+        ORDER BY created_at, id LIMIT 10`,
+      [T1, C1, "2020-01-01T00:00:00.000Z", "m0000"],
+    );
+    const text = plan.map((r) => Object.values(r)[0]).join("\n");
+    expect(text).not.toContain("Seq Scan");
+  });
+});
+
+describe("agent and binding specifics", () => {
+  const manifest = (id: string, version: number): AgentManifest => ({
+    id,
+    version,
+    name: `agent ${id} v${version}`,
+    description: "fixture",
+    instructions: "be useful",
+    modelPolicy: { preferred: "claude-opus-5" },
+    responseFormat: { kind: "text" },
+    toolPolicy: { allow: [] },
+    skillPolicy: { allow: [] },
+    authorizationPolicyId: "default",
+    contextProviderIds: [],
+    limits: { maxSteps: 4, maxToolCalls: 8, maxWallClockMs: 60_000 },
+  });
+
+  it("keeps v1 resolvable after v2 is registered", async () => {
+    const sql = await migrated();
+    const store = createPostgresAgentStore(sql);
+    await store.put(T1, manifest("a", 1));
+    await store.put(T1, manifest("a", 2));
+    // A thread pinned to v1 must still resolve v1 — that is what per-version keying buys.
+    expect(await store.findByVersion({ tenantId: T1, agentId: "a", version: 1 })).toMatchObject({ version: 1 });
+    expect(await store.findByVersion({ tenantId: T1, agentId: "a", version: 2 })).toMatchObject({ version: 2 });
+  });
+
+  it("does not leak a manifest across tenants", async () => {
+    const sql = await migrated();
+    const store = createPostgresAgentStore(sql);
+    await store.put(T1, manifest("a", 1));
+    // The regression #91 found in the in-memory adapter, asserted for Postgres too.
+    expect(await store.findByVersion({ tenantId: T2, agentId: "a", version: 1 })).toBeNull();
+  });
+
+  it("round-trips a pinned binding and then a re-bind to latest", async () => {
+    const sql = await withConversation();
+    const store = createPostgresConversationBindingStore(sql);
+    await store.bind({
+      tenantId: T1,
+      conversationId: C1,
+      agentId: AGENT,
+      agentVersionPolicy: "pinned",
+      agentVersion: 3,
+    });
+    expect(await store.get({ tenantId: T1, conversationId: C1 })).toEqual({
+      conversationId: C1,
+      agentId: AGENT,
+      agentVersionPolicy: "pinned",
+      agentVersion: 3,
+    });
+
+    await store.bind({ tenantId: T1, conversationId: C1, agentId: AGENT, agentVersionPolicy: "latest" });
+    const rebound = await store.get({ tenantId: T1, conversationId: C1 });
+    expect(rebound?.agentVersionPolicy).toBe("latest");
+    // Absent, not null: a `latest` binding has no version, and a null would round-trip as
+    // present-but-empty.
+    expect(rebound && "agentVersion" in rebound).toBe(false);
+  });
+});

--- a/backend/src/adapters/postgres/index.ts
+++ b/backend/src/adapters/postgres/index.ts
@@ -11,6 +11,7 @@ export * from "./conversation-store.js";
 export * from "./run-store.js";
 export * from "./run-event-log.js";
 export * from "./checkpoint-store.js";
+export * from "./message-store.js";
 export * from "./pg-executor.js";
 
 /** Capabilities a PostgreSQL deployment can advertise (docs/02 capability declarations). */

--- a/backend/src/adapters/postgres/message-store.ts
+++ b/backend/src/adapters/postgres/message-store.ts
@@ -1,0 +1,200 @@
+/**
+ * PostgreSQL `MessageStore`, `AgentStore` and `ConversationBindingStore` (#96) — the stores that make
+ * a conversation durable rather than a thing that exists until the next deploy.
+ *
+ * Paging uses the same `(created_at, id)` composite cursor as `createPostgresConversationStore`. That
+ * pairing is the whole of AC-2: a timestamp alone lets a concurrently-inserted row sharing the same
+ * `created_at` slip between pages, and `OFFSET` shifts every subsequent page when a row lands early.
+ * The `id` tiebreak plus a keyset comparison makes the sequence stable while the conversation is
+ * still being written to.
+ */
+import { AgentPlatformError } from "../../core/errors.js";
+import type { Page } from "../../core/context.js";
+import type { Message } from "../../core/content-parts.js";
+import type { AgentManifest } from "../../agents/index.js";
+import type { AgentId, ConversationId, MessageId, RunId, TenantId } from "../../core/ids.js";
+import type {
+  AgentStore,
+  ConversationBinding,
+  ConversationBindingStore,
+  MessageStore,
+} from "../../persistence/index.js";
+import { parseMessagePart } from "../../core/validation.js";
+import type { SqlExecutor } from "./sql.js";
+
+type MessageRow = {
+  tenant_id: string;
+  id: string;
+  conversation_id: string;
+  run_id: string | null;
+  role: string;
+  parts: unknown;
+  created_at: string | Date;
+};
+
+const iso = (v: string | Date): string => (v instanceof Date ? v.toISOString() : new Date(v).toISOString());
+
+const invalid = (message: string) =>
+  new AgentPlatformError({ code: "invalid_input", message, retryable: false });
+
+/**
+ * Validate on read. A hand-edited or half-migrated `parts` column otherwise flows into a client's
+ * stream, where the failure surfaces far from its cause — so the error names the message that carries
+ * the bad payload (AC-5).
+ */
+const toMessage = (r: MessageRow): Message => {
+  const stored = typeof r.parts === "string" ? JSON.parse(r.parts) : r.parts;
+  if (!Array.isArray(stored)) throw invalid(`Message ${r.id} has a non-array parts column`);
+  // There is no whole-message validator, so each part goes through `parseMessagePart`. Wrapping the
+  // failure keeps the message id in the error — otherwise a bad row reports only "invalid part" and
+  // leaves you grepping a table for it (AC-5).
+  let parts;
+  try {
+    parts = stored.map(parseMessagePart);
+  } catch (cause) {
+    throw invalid(`Message ${r.id} has an invalid stored part: ${(cause as Error).message}`);
+  }
+  return {
+    id: r.id as MessageId,
+    conversationId: r.conversation_id as ConversationId,
+    ...(r.run_id === null ? {} : { runId: r.run_id as RunId }),
+    role: r.role as Message["role"],
+    parts,
+    createdAt: iso(r.created_at),
+  };
+};
+
+const encodeCursor = (r: MessageRow): string =>
+  Buffer.from(JSON.stringify({ c: iso(r.created_at), i: r.id })).toString("base64");
+const decodeCursor = (cursor: string): { c: string; i: string } =>
+  JSON.parse(Buffer.from(cursor, "base64").toString("utf8"));
+
+export const createPostgresMessageStore = (
+  sql: SqlExecutor,
+): MessageStore & { append(tenantId: string, message: Message): Promise<void> } => ({
+  /**
+   * Beyond the read-only port, mirroring the in-memory adapter's test-only affordance. Messages are
+   * immutable once written — there is deliberately no update path, since editing one would rewrite
+   * history a client has already streamed.
+   */
+  async append(tenantId, message) {
+    await sql.query(
+      `INSERT INTO messages (tenant_id, id, conversation_id, run_id, role, parts, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::timestamptz)
+       ON CONFLICT (tenant_id, id) DO NOTHING`,
+      [
+        tenantId,
+        message.id,
+        message.conversationId,
+        message.runId ?? null,
+        message.role,
+        JSON.stringify(message.parts),
+        message.createdAt,
+      ],
+    );
+  },
+
+  async findById({ tenantId, id }) {
+    const rows = await sql.query<MessageRow>(
+      `SELECT * FROM messages WHERE tenant_id = $1 AND id = $2`,
+      [tenantId, id],
+    );
+    const row = rows[0];
+    return row ? toMessage(row) : null;
+  },
+
+  async listByConversation({ tenantId, conversationId, limit, cursor }) {
+    const params: unknown[] = [tenantId, conversationId, limit + 1];
+    let where = `tenant_id = $1 AND conversation_id = $2`;
+    if (cursor) {
+      const { c, i } = decodeCursor(cursor);
+      // Keyset, not OFFSET: strictly after (created_at, id), so an insert landing earlier in the
+      // ordering cannot shift this page or duplicate a row into the next one.
+      where += ` AND (created_at, id) > ($4::timestamptz, $5)`;
+      params.push(c, i);
+    }
+    const rows = await sql.query<MessageRow>(
+      `SELECT * FROM messages WHERE ${where} ORDER BY created_at, id LIMIT $3`,
+      params,
+    );
+    const hasMore = rows.length > limit;
+    const items = (hasMore ? rows.slice(0, limit) : rows).map(toMessage);
+    const last = hasMore ? rows[limit - 1] : undefined;
+    const page: Page<Message> = last ? { items, nextCursor: encodeCursor(last) } : { items };
+    return page;
+  },
+});
+
+type AgentRow = { manifest: unknown };
+
+export const createPostgresAgentStore = (
+  sql: SqlExecutor,
+): AgentStore & { put(tenantId: string, manifest: AgentManifest): Promise<void> } => ({
+  async put(tenantId, manifest) {
+    await sql.query(
+      `INSERT INTO agents (tenant_id, id, version, manifest, created_at, updated_at)
+       VALUES ($1, $2, $3, $4::jsonb, now(), now())
+       ON CONFLICT (tenant_id, id, version) DO UPDATE
+          SET manifest = excluded.manifest, updated_at = now()`,
+      [tenantId, manifest.id, manifest.version, JSON.stringify(manifest)],
+    );
+  },
+
+  async findByVersion({ tenantId, agentId, version }) {
+    // Tenant-scoped, unlike the in-memory adapter before #91 fixed it: a manifest is owned by the
+    // tenant that registered it, and the key leads with tenant_id so a cross-tenant read is a miss.
+    const rows = await sql.query<AgentRow>(
+      `SELECT manifest FROM agents WHERE tenant_id = $1 AND id = $2 AND version = $3`,
+      [tenantId, agentId, version],
+    );
+    const row = rows[0];
+    if (!row) return null;
+    return (typeof row.manifest === "string" ? JSON.parse(row.manifest) : row.manifest) as AgentManifest;
+  },
+});
+
+type BindingRow = {
+  conversation_id: string;
+  agent_id: string;
+  agent_version_policy: string;
+  agent_version: number | null;
+};
+
+const toBinding = (r: BindingRow): ConversationBinding => ({
+  conversationId: r.conversation_id as ConversationId,
+  agentId: r.agent_id as AgentId,
+  agentVersionPolicy: r.agent_version_policy as ConversationBinding["agentVersionPolicy"],
+  // Absent rather than null for a `latest` binding: the type makes it optional, and a null here
+  // would round-trip as a present-but-empty version.
+  ...(r.agent_version === null ? {} : { agentVersion: r.agent_version }),
+});
+
+export const createPostgresConversationBindingStore = (sql: SqlExecutor): ConversationBindingStore => ({
+  async bind({ tenantId, conversationId, agentId, agentVersionPolicy, agentVersion }) {
+    // Idempotent by conversation: re-binding is a legitimate operation (an agent upgrade), not a
+    // conflict, so the last write wins rather than erroring.
+    await sql.query(
+      `INSERT INTO conversation_bindings
+         (tenant_id, conversation_id, agent_id, agent_version_policy, agent_version, bound_at)
+       VALUES ($1, $2, $3, $4, $5, now())
+       ON CONFLICT (tenant_id, conversation_id) DO UPDATE
+          SET agent_id             = excluded.agent_id,
+              agent_version_policy = excluded.agent_version_policy,
+              agent_version        = excluded.agent_version,
+              bound_at             = excluded.bound_at`,
+      [tenantId, conversationId, agentId, agentVersionPolicy, agentVersion ?? null],
+    );
+  },
+
+  async get({ tenantId, conversationId }) {
+    const rows = await sql.query<BindingRow>(
+      `SELECT conversation_id, agent_id, agent_version_policy, agent_version
+         FROM conversation_bindings WHERE tenant_id = $1 AND conversation_id = $2`,
+      [tenantId, conversationId],
+    );
+    const row = rows[0];
+    return row ? toBinding(row) : null;
+  },
+});
+
+export type { MessageId, RunId, TenantId };

--- a/backend/src/adapters/postgres/migrations.ts
+++ b/backend/src/adapters/postgres/migrations.ts
@@ -132,6 +132,73 @@ export const MIGRATIONS: readonly Migration[] = [
     ],
     down: [`DROP TABLE IF EXISTS checkpoints`],
   },
+  {
+    // #96 — the conversation itself: its messages, the agent manifests, and the binding that says
+    // which agent version owns a thread.
+    id: "0005_messages_agents",
+    up: [
+      `CREATE TABLE IF NOT EXISTS messages (
+        tenant_id       text        NOT NULL,
+        id              text        NOT NULL,
+        conversation_id text        NOT NULL,
+        run_id          text,
+        role            text        NOT NULL,
+        parts           jsonb       NOT NULL,
+        created_at      timestamptz NOT NULL,
+        PRIMARY KEY (tenant_id, id),
+        CONSTRAINT messages_conversation_fk
+          FOREIGN KEY (tenant_id, conversation_id) REFERENCES conversations (tenant_id, id)
+          ON DELETE CASCADE
+      )`,
+      // The composite ordering the stable cursor pages on. `id` breaks ties, which is what makes
+      // paging safe under concurrent inserts sharing a created_at — a timestamp alone would let a
+      // row slip between pages.
+      `CREATE INDEX IF NOT EXISTS messages_tenant_conversation_created_idx
+        ON messages (tenant_id, conversation_id, created_at, id)`,
+      // One row per version: a thread pinned to v1 must still resolve v1 after v2 is registered.
+      // Tenant-leading — this is the store whose in-memory version leaked across tenants (#91).
+      `CREATE TABLE IF NOT EXISTS agents (
+        tenant_id  text        NOT NULL,
+        id         text        NOT NULL,
+        version    integer     NOT NULL,
+        manifest   jsonb       NOT NULL,
+        created_at timestamptz NOT NULL,
+        updated_at timestamptz NOT NULL,
+        PRIMARY KEY (tenant_id, id, version),
+        CONSTRAINT agents_version_positive CHECK (version > 0)
+      )`,
+      // agent_version_policy was absent from the SPEC. Without it a binding cannot express what it
+      // exists to express, and agent_version is NULL for a 'latest' binding — hence nullable, with a
+      // constraint tying the two together instead of leaving the pair free to contradict itself.
+      //
+      // No foreign key to `agents`: a 'latest' binding carries no version, so a composite
+      // (agent_id, agent_version) reference cannot be enforced for it, and binding to an agent whose
+      // manifest is not yet registered is legitimate.
+      `CREATE TABLE IF NOT EXISTS conversation_bindings (
+        tenant_id            text        NOT NULL,
+        conversation_id      text        NOT NULL,
+        agent_id             text        NOT NULL,
+        agent_version_policy text        NOT NULL,
+        agent_version        integer,
+        bound_at             timestamptz NOT NULL,
+        PRIMARY KEY (tenant_id, conversation_id),
+        CONSTRAINT conversation_bindings_conversation_fk
+          FOREIGN KEY (tenant_id, conversation_id) REFERENCES conversations (tenant_id, id)
+          ON DELETE CASCADE,
+        CONSTRAINT conversation_bindings_policy_check
+          CHECK (agent_version_policy IN ('pinned', 'latest')),
+        CONSTRAINT conversation_bindings_pinned_has_version
+          CHECK ((agent_version_policy = 'pinned' AND agent_version IS NOT NULL)
+              OR (agent_version_policy = 'latest'))
+      )`,
+    ],
+    down: [
+      `DROP TABLE IF EXISTS conversation_bindings`,
+      `DROP TABLE IF EXISTS agents`,
+      `DROP INDEX IF EXISTS messages_tenant_conversation_created_idx`,
+      `DROP TABLE IF EXISTS messages`,
+    ],
+  },
 ];
 
 export const migrate = async (sql: SqlExecutor): Promise<void> => {

--- a/backend/src/testing/conformance/checkpoint-store.ts
+++ b/backend/src/testing/conformance/checkpoint-store.ts
@@ -5,10 +5,9 @@
  *
  * **Referential integrity (#95).** A checkpoint belongs to a run, and an adapter is entitled to
  * enforce that — the Postgres schema does, with a foreign key, because an orphan checkpoint is
- * meaningless. The in-memory adapter holds no such constraint. So the fixture may supply `seedRun`,
- * which the harness calls before every save; adapters without referential integrity omit it and
- * nothing changes for them. Without this the suite would have forced a choice between "the harness
- * passes" and "orphan checkpoints are impossible", and the second is the property that matters.
+ * meaningless. The in-memory adapter holds no such constraint. The fixture may therefore supply
+ * `seedRun`, via the shared `parents` helper (#96 generalised what started here); adapters without
+ * referential integrity omit it and nothing changes for them.
  */
 
 import { describe, expect, it } from "vitest";
@@ -16,6 +15,7 @@ import { asId } from "../../core/ids.js";
 import type { RunId, TenantId } from "../../core/ids.js";
 import type { CheckpointStore } from "../../persistence/index.js";
 import { emptyCheckpoint, type RunCheckpoint } from "../../runtime/checkpoint.js";
+import { withRun, type FixtureOrStore } from "./parents.js";
 
 const T1 = asId<TenantId>("conf-tenant-1");
 const T2 = asId<TenantId>("conf-tenant-2");
@@ -27,23 +27,9 @@ const at = (runId: RunId, sequence: number, step = 0): RunCheckpoint => ({
   step,
 });
 
-/**
- * What an adapter supplies. `seedRun` creates whatever parent row the adapter's constraints require;
- * returning the store and the seeder together lets both share one executor.
- */
-export type CheckpointFixture = {
-  readonly store: CheckpointStore;
-  readonly seedRun?: (input: { readonly tenantId: TenantId; readonly runId: RunId }) => Promise<void>;
-};
-
-export function checkpointStoreConformance(makeFixture: () => CheckpointStore | CheckpointFixture): void {
-  /** Accepts a bare store (adapters with no referential integrity) or a full fixture. */
-  const open = async (runIds: readonly { tenantId: TenantId; runId: RunId }[] = [{ tenantId: T1, runId: RUN }]) => {
-    const made = makeFixture();
-    const fixture: CheckpointFixture = "store" in made ? made : { store: made };
-    if (fixture.seedRun) for (const r of runIds) await fixture.seedRun(r);
-    return fixture.store;
-  };
+export function checkpointStoreConformance(makeFixture: () => FixtureOrStore<CheckpointStore>): void {
+  const open = (runIds: readonly { tenantId: TenantId; runId: RunId }[] = [{ tenantId: T1, runId: RUN }]) =>
+    withRun(makeFixture(), runIds);
 
   describe("CheckpointStore conformance", () => {
     it("returns null before anything is saved", async () => {

--- a/backend/src/testing/conformance/index.ts
+++ b/backend/src/testing/conformance/index.ts
@@ -15,6 +15,7 @@
  */
 
 export * from "./capability.js";
+export * from "./parents.js";
 export * from "./conversation-store.js";
 export * from "./run-store.js";
 export * from "./run-event-log.js";
@@ -153,9 +154,6 @@ const SUPABASE_ALIASED: readonly string[] = ["ConversationStore"];
 
 /** Ports with no Postgres store yet, each against the SPEC that adds it (REQ-010→013). */
 const POSTGRES_PENDING: readonly { readonly port: string; readonly trackedBy: string }[] = [
-  { port: "MessageStore", trackedBy: "#96" },
-  { port: "AgentStore", trackedBy: "#96" },
-  { port: "ConversationBindingStore", trackedBy: "#96" },
   { port: "SessionStateStore", trackedBy: "#97" },
   { port: "ThreadSummaryStore", trackedBy: "#97" },
   { port: "ConversationRunCoordinator", trackedBy: "#98" },
@@ -180,7 +178,15 @@ export const ADAPTER_COVERAGE: readonly AdapterCoverage[] = [
   },
   {
     adapter: "postgres",
-    implemented: ["ConversationStore", "RunStore", "RunEventLog", "CheckpointStore"],
+    implemented: [
+      "ConversationStore",
+      "RunStore",
+      "RunEventLog",
+      "CheckpointStore",
+      "MessageStore",
+      "AgentStore",
+      "ConversationBindingStore",
+    ],
     notImplemented: POSTGRES_PENDING,
   },
   {

--- a/backend/src/testing/conformance/parents.ts
+++ b/backend/src/testing/conformance/parents.ts
@@ -1,0 +1,63 @@
+/**
+ * Parent seeding for the conformance suite.
+ *
+ * An adapter is entitled to enforce referential integrity, and the Postgres schema does: a checkpoint
+ * belongs to a run, a message and a binding belong to a conversation. The in-memory reference adapter
+ * holds no such constraint, so the shared harnesses never created those parent rows — and every
+ * foreign key added to the schema broke them.
+ *
+ * #95 solved that for `CheckpointStore` with a bespoke fixture type. #96 needed the same thing for
+ * `ConversationBindingStore`, which is the point at which a one-off becomes a pattern. This is the
+ * shared mechanism: a harness accepts either a bare store (adapters with no constraints, unchanged)
+ * or a fixture pairing the store with the seeders its constraints require.
+ *
+ * The alternative was to drop the foreign keys so the harness would pass, which would have traded a
+ * real guarantee — orphan rows are impossible — for a green suite. That is the wrong direction.
+ */
+
+import type { ConversationId, RunId, TenantId } from "../../core/ids.js";
+
+/** Creates whatever parent row an adapter's constraints require. Omitted when there are none. */
+export type ParentSeeders = {
+  readonly seedRun?: (input: { readonly tenantId: TenantId; readonly runId: RunId }) => Promise<void>;
+  readonly seedConversation?: (input: {
+    readonly tenantId: TenantId;
+    readonly conversationId: ConversationId;
+  }) => Promise<void>;
+};
+
+/** A store plus the seeders its adapter needs. Harnesses accept this or a bare store. */
+export type Fixture<TStore> = ParentSeeders & { readonly store: TStore };
+
+/** What a harness is handed: either shape. */
+export type FixtureOrStore<TStore> = TStore | Fixture<TStore>;
+
+const isFixture = <TStore>(value: FixtureOrStore<TStore>): value is Fixture<TStore> =>
+  typeof value === "object" && value !== null && "store" in value;
+
+/**
+ * Normalise whichever shape the adapter supplied. Returns the store and the seeders, so a harness can
+ * seed unconditionally without caring which form it was given.
+ */
+export const openFixture = <TStore>(made: FixtureOrStore<TStore>): Fixture<TStore> =>
+  isFixture(made) ? made : { store: made };
+
+/** Seed a run if the adapter needs one, then hand back the store. */
+export const withRun = async <TStore>(
+  made: FixtureOrStore<TStore>,
+  runs: readonly { tenantId: TenantId; runId: RunId }[],
+): Promise<TStore> => {
+  const fixture = openFixture(made);
+  if (fixture.seedRun) for (const r of runs) await fixture.seedRun(r);
+  return fixture.store;
+};
+
+/** Seed a conversation if the adapter needs one, then hand back the store. */
+export const withConversation = async <TStore>(
+  made: FixtureOrStore<TStore>,
+  conversations: readonly { tenantId: TenantId; conversationId: ConversationId }[],
+): Promise<TStore> => {
+  const fixture = openFixture(made);
+  if (fixture.seedConversation) for (const c of conversations) await fixture.seedConversation(c);
+  return fixture.store;
+};

--- a/backend/src/testing/conformance/records.ts
+++ b/backend/src/testing/conformance/records.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { withConversation, type FixtureOrStore } from "./parents.js";
 import { asId } from "../../core/ids.js";
 import type { MessageId, PrincipalId, RunId, TenantId, ToolCallId } from "../../core/ids.js";
 import type {
@@ -32,24 +33,30 @@ const RUN = asId<RunId>("conf-run-1");
 const C1 = asId<ConversationId>("conf-convo-1");
 
 export function messageStoreConformance(
-  makeStore: () => MessageStore,
+  makeFixture: () => FixtureOrStore<MessageStore>,
   seed: (store: MessageStore, input: { tenantId: TenantId; conversationId: ConversationId; count: number }) => Promise<void>,
 ): void {
+  // A message references a conversation, and Postgres enforces that with a foreign key (#96). The
+  // seed callback only receives the store, so it cannot create the parent itself — the fixture's
+  // `seedConversation` does, sharing the adapter's executor. See ./parents.ts.
+  const open = (conversationId: ConversationId = C1) =>
+    withConversation(makeFixture(), [{ tenantId: T1, conversationId }]);
+
   describe("MessageStore conformance", () => {
     it("returns null for an unknown id", async () => {
-      const store = makeStore();
+      const store = await open();
       expect(await store.findById({ tenantId: T1, id: asId<MessageId>("nope") })).toBeNull();
     });
 
     it("lists a conversation's messages in order", async () => {
-      const store = makeStore();
+      const store = await open();
       await seed(store, { tenantId: T1, conversationId: C1, count: 3 });
       const page = await store.listByConversation({ tenantId: T1, conversationId: C1, limit: 10 });
       expect(page.items).toHaveLength(3);
     });
 
     it("pages by stable cursor with no overlap between pages", async () => {
-      const store = makeStore();
+      const store = await open();
       await seed(store, { tenantId: T1, conversationId: C1, count: 5 });
       const first = await store.listByConversation({ tenantId: T1, conversationId: C1, limit: 2 });
       expect(first.items).toHaveLength(2);
@@ -65,7 +72,7 @@ export function messageStoreConformance(
     });
 
     it("preserves typed content parts through a round-trip", async () => {
-      const store = makeStore();
+      const store = await open();
       await seed(store, { tenantId: T1, conversationId: C1, count: 1 });
       const page = await store.listByConversation({ tenantId: T1, conversationId: C1, limit: 1 });
       const message = page.items[0];
@@ -74,7 +81,7 @@ export function messageStoreConformance(
     });
 
     it("enforces tenant isolation", async () => {
-      const store = makeStore();
+      const store = await open();
       await seed(store, { tenantId: T1, conversationId: C1, count: 2 });
       const other = await store.listByConversation({ tenantId: T2, conversationId: C1, limit: 10 });
       expect(other.items).toHaveLength(0);

--- a/backend/src/testing/conformance/session-state.ts
+++ b/backend/src/testing/conformance/session-state.ts
@@ -18,6 +18,7 @@ import type {
   UnitOfWork,
 } from "../../persistence/index.js";
 import { gatedIt, type AdapterDeclaration } from "./capability.js";
+import { withConversation, type FixtureOrStore } from "./parents.js";
 
 const T1 = asId<TenantId>("conf-tenant-1");
 const T2 = asId<TenantId>("conf-tenant-2");
@@ -75,15 +76,20 @@ export function sessionStateStoreConformance(
 }
 
 export function conversationBindingStoreConformance(
-  makeStore: () => ConversationBindingStore,
+  makeFixture: () => FixtureOrStore<ConversationBindingStore>,
 ): void {
+  // A binding belongs to a conversation, and Postgres enforces that with a foreign key (#96). The
+  // in-memory adapter has no such constraint and passes no seeder — see ./parents.ts.
+  const open = () => withConversation(makeFixture(), [{ tenantId: T1, conversationId: C1 }]);
+
   describe("ConversationBindingStore conformance", () => {
     it("returns null for an unbound conversation rather than a default", async () => {
-      expect(await makeStore().get({ tenantId: T1, conversationId: C1 })).toBeNull();
+      const store = await open();
+      expect(await store.get({ tenantId: T1, conversationId: C1 })).toBeNull();
     });
 
     it("round-trips a pinned binding including the version", async () => {
-      const store = makeStore();
+      const store = await open();
       await store.bind({
         tenantId: T1,
         conversationId: C1,
@@ -99,7 +105,7 @@ export function conversationBindingStoreConformance(
     });
 
     it("round-trips a latest-policy binding", async () => {
-      const store = makeStore();
+      const store = await open();
       await store.bind({ tenantId: T1, conversationId: C1, agentId: AGENT, agentVersionPolicy: "latest" });
       expect(await store.get({ tenantId: T1, conversationId: C1 })).toMatchObject({
         agentVersionPolicy: "latest",
@@ -107,7 +113,7 @@ export function conversationBindingStoreConformance(
     });
 
     it("re-binding is idempotent — the last write wins, without error", async () => {
-      const store = makeStore();
+      const store = await open();
       await store.bind({ tenantId: T1, conversationId: C1, agentId: AGENT, agentVersionPolicy: "latest" });
       await store.bind({
         tenantId: T1,
@@ -120,7 +126,7 @@ export function conversationBindingStoreConformance(
     });
 
     it("enforces tenant isolation", async () => {
-      const store = makeStore();
+      const store = await open();
       await store.bind({ tenantId: T1, conversationId: C1, agentId: AGENT, agentVersionPolicy: "latest" });
       expect(await store.get({ tenantId: T2, conversationId: C1 })).toBeNull();
     });

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -5,5 +5,19 @@ export default defineConfig({
     // Only run source tests — never stale compiled copies under dist/.
     include: ["src/**/*.test.ts"],
     exclude: ["node_modules/**", "dist/**"],
+    /**
+     * The Postgres conformance harnesses build a store per test, and each one starts its own PGlite
+     * (an embedded Postgres compiled to WASM). With ~113 such tests across parallel files, a single
+     * test can legitimately wait seconds for CPU — so the 5s default was timing out tests that were
+     * making progress, not hanging. That reads as flakiness, and a suite people re-run until green
+     * is worse than a slow one.
+     *
+     * This raises the ceiling; it does not fix the cause. The real fix is one PGlite per file with
+     * per-test schema isolation (the real-server executor already works that way), which matters
+     * because #97→#102 add twelve more ports to the same entrypoint. Tracked separately rather than
+     * folded into #96.
+     */
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
Closes #96

## Summary

Adds the three Postgres stores that make a conversation durable: `MessageStore`, `AgentStore` and
`ConversationBindingStore`. All three lived only in `src/adapters/memory/message-store.ts` — whose own
header says it backs the embedded `createAgent` facade and tests — so reopening a thread after a
deploy showed an empty conversation and forgot which agent version owned it.

Takes the matrix to **postgres 7/19** and opens REQ-011 (#68).

## Three corrections to the SPEC, amended on the issue

**1. `conversation_bindings` was missing the column that gives it meaning.** The SPEC listed
`(tenant_id, conversation_id, agent_id, agent_version, bound_at)`, but `ConversationBinding` requires
**`agentVersionPolicy`** (`'pinned' | 'latest'`). Without it, a thread pinned to v3 is
indistinguishable from one following the latest — the record's entire purpose — and the harness
asserts both round-trip. `agent_version` is nullable, since a `latest` binding records no version.

**2. `agents` had no primary key**, only a column list. `findByVersion({ agentId, version })` implies
`(tenant_id, id, version)`. Tenant-leading deliberately: this is the store whose in-memory version
leaked across tenants in #91.

**3. The DoD named `develop`** rather than `main`.

The `messages` columns were correct — they match the `Message` type exactly.

## Generalising #95's fixture hook rather than repeating it

Both `messages` and `conversation_bindings` reference a conversation, so following #95's precedent
(orphan rows impossible, not merely unlikely) they get foreign keys to `conversations`.

That breaks the shared harnesses exactly as #95's checkpoint foreign key did, because the in-memory
adapter has no referential integrity and the harnesses create no parent row. `messageStoreConformance`
and `agentStoreConformance` already take seed callbacks; `conversationBindingStoreConformance` does
not.

This is the second occurrence, which is the point at which the ad-hoc version should stop: #95's
one-off `CheckpointFixture` is **extracted into a shared parent-seeding helper** that the harnesses
use uniformly. Adapters without referential integrity keep passing nothing and are unaffected.

**No foreign key from `conversation_bindings` to `agents`** — a `latest` binding carries no version, so
a composite key cannot be enforced for it, and binding to an agent whose manifest is not yet
registered is legitimate.

## Test plan

- All three harnesses against Postgres, with the three ports moved to `implemented` in
  `ADAPTER_COVERAGE`.
- **Paging under concurrent inserts (AC-2)**: page a 500-message conversation while inserting more,
  asserting no duplicate and no skipped message. This is the criterion a naive `OFFSET` pager fails,
  so it is tested with live inserts rather than nominally — the stable `(created_at, id)` cursor is
  what makes it hold.
- A mixed-part message (text + tool result + attachment ref) round-tripping under deep equality.
- A deliberately corrupted `parts` row raising a typed error that names the message (AC-5).
- Migration round-trip; `EXPLAIN` on the paging query; cascade removing messages and bindings with
  their conversation; `agents` keyed per version so v1 stays resolvable after v2 exists.

## One deliberate asymmetry

`messages` gets no `updated_at` and no soft delete, unlike `conversations`. That matches the port —
`MessageStore` is read-only apart from the in-memory adapter's test-only `append`, and messages are
immutable once written: editing one would rewrite history a client has already streamed. Recorded so
it reads as a decision rather than an omission.
